### PR TITLE
Docker PHP dependencies, Make task runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,12 @@ services:
 php:
   - 7.1
 
-before_install:
-  - docker build -t wmde/fundraising-donations .
-
 install:
   - travis_retry composer install
 
 script:
-  - composer ci
-  - docker run -it --rm -v $PWD:/usr/src/myapp -w /usr/src/myapp wmde/fundraising-donations ./vendor/bin/phpunit
+  - composer validate --no-interaction
+  - make ci
 
 after_success:
   - if [[ "`phpenv version-name`" != "7.1" ]]; then exit 0; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: php
 
+services:
+  - docker
+
 php:
   - 7.1
-  - master
 
-sudo: false
+before_install:
+  - docker build -t wmde/fundraising-donations .
 
-install: travis_retry composer install
+install:
+  - travis_retry composer install
 
-script: composer ci
+script:
+  - composer ci
+  - docker run -it --rm -v $PWD:/usr/src/myapp -w /usr/src/myapp wmde/fundraising-donations ./vendor/bin/phpunit
 
 after_success:
   - if [[ "`phpenv version-name`" != "7.1" ]]; then exit 0; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.1-cli
+
+RUN \
+	apt-get update && \
+	# for intl
+	apt-get install -y libicu-dev && \
+	docker-php-ext-install -j$(nproc) intl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+ci: covers phpunit cs stan
+
+test: covers phpunit
+
+covers:
+	docker-compose run --rm app ./vendor/bin/covers-validator
+
+phpunit:
+	docker-compose run --rm app ./vendor/bin/phpunit
+
+cs:
+	docker-compose run --rm app ./vendor/bin/phpcs
+
+stan:
+	docker-compose run --rm app ./vendor/bin/phpstan analyse --level=1 --no-progress contexts/ src/ tests/
+
+.PHONY: covers phpunit cs stan

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 EXPERIMENTAL (such T4) extract of the Donation Context out of the FundraisingFrontend git repo.
 
 [![Build Status](https://travis-ci.org/wmde/fundraising-donations.svg?branch=master)](https://travis-ci.org/wmde/fundraising-donations)
+
+## Development
+
+### Install dependencies
+
+    docker run -it --rm --user $(id -u):$(id -g) -v ~/.composer:/composer -v $(pwd):/app docker.io/composer
+
+### Build application container
+
+    docker build -t wmde/fundraising-donations .
+
+### Run tests
+
+    docker run -it --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp wmde/fundraising-donations ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ EXPERIMENTAL (such T4) extract of the Donation Context out of the FundraisingFro
 
     docker run -it --rm --user $(id -u):$(id -g) -v ~/.composer:/composer -v $(pwd):/app docker.io/composer
 
-### Build application container
-
-    docker build -t wmde/fundraising-donations .
-
 ### Run tests
 
-    docker run -it --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp wmde/fundraising-donations ./vendor/bin/phpunit
+    make ci
+
+This implicitly builds the `app` container as defined in `docker-compose.yml` & `Dockerfile`
+and runs various code quality checks.
+
+#### PHPUnit with filter
+
+Individual commands like PHPUnit with a filter can be run like
+
+   docker-compose run --rm app ./vendor/bin/phpunit --filter valid

--- a/composer.json
+++ b/composer.json
@@ -40,28 +40,6 @@
 			"WMDE\\Fundraising\\Frontend\\PaymentContext\\Tests\\": "contexts/PaymentContext/tests/"
 		}
 	},
-	"scripts": {
-		"test": [
-			"composer validate --no-interaction",
-			"vendor/bin/covers-validator",
-			"vendor/bin/phpunit"
-		],
-		"cs": [
-			"@phpcs"
-		],
-		"ci": [
-			"@test",
-			"@cs",
-			"@stan"
-		],
-		"phpcs": [
-			"vendor/bin/phpcs"
-		],
-		"phpmd": [
-			"vendor/bin/phpmd src/ text phpmd.xml"
-		],
-		"stan": "./vendor/bin/phpstan analyse --level=1 --no-progress contexts/ src/ tests/"
-	},
 	"config": {
 		"discard-changes": true
 	},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/usr/src/app
+    working_dir: /usr/src/app


### PR DESCRIPTION
* use Docker & docker-compose to describe application
  * installs `intl` extension in addition to the ones provided by 7.1-cli (if you know explicit dependencies, feel free to add them to the `Dockerfile`)
* use make as a task runner as alternative to composer (which does not go well with containerization. Run e.g. `make ci` (see README for more)
