### PR TITLE
Change initial status of sofort donations

### DIFF
--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -199,6 +199,11 @@ class Donation {
 			$this->makeCommentPrivate();
 		}
 
+		if ( $this->getPaymentType() === PaymentType::SOFORT ) {
+			$this->status = self::STATUS_PROMISE;
+			return;
+		}
+
 		$this->status = self::STATUS_EXTERNAL_BOOKED;
 	}
 

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -199,11 +199,6 @@ class Donation {
 			$this->makeCommentPrivate();
 		}
 
-		if ( $this->getPaymentType() === PaymentType::SOFORT ) {
-			$this->status = self::STATUS_PROMISE;
-			return;
-		}
-
 		$this->status = self::STATUS_EXTERNAL_BOOKED;
 	}
 

--- a/src/UseCases/AddDonation/InitialDonationStatusPicker.php
+++ b/src/UseCases/AddDonation/InitialDonationStatusPicker.php
@@ -14,8 +14,6 @@ class InitialDonationStatusPicker {
 			return Donation::STATUS_NEW;
 		} elseif ( $paymentType === PaymentType::BANK_TRANSFER ) {
 			return Donation::STATUS_PROMISE;
-		} elseif ( $paymentType === PaymentType::SOFORT ) {
-			return Donation::STATUS_PROMISE;
 		}
 
 		return Donation::STATUS_EXTERNAL_INCOMPLETE;

--- a/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
+++ b/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
@@ -58,6 +58,13 @@ class SofortPaymentNotificationUseCase {
 			return $this->createUnhandledResponse( 'Duplicate notification' );
 		}
 
+		try {
+			$donation->confirmBooked();
+		}
+		catch ( \RuntimeException $ex ) {
+			return $this->createFailureResponse( $ex );
+		}
+
 		$paymentMethod->setConfirmedAt( $request->getTime() );
 
 		try {

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -115,7 +115,7 @@ class ValidDonation {
 	public static function newIncompleteSofortDonation(): Donation {
 		return ( new self() )->createDonation(
 			new SofortPayment( self::PAYMENT_BANK_TRANSFER_CODE ),
-			Donation::STATUS_PROMISE
+			Donation::STATUS_EXTERNAL_INCOMPLETE
 		);
 	}
 

--- a/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -100,7 +100,7 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 		$this->assertCount( 1, $repositorySpy->getStoreDonationCalls() );
 	}
 
-	public function testWhenAuthorizationSucceeds_donationIsStillPromised(): void {
+	public function testWhenAuthorizationSucceeds_donationIsStillBooked(): void {
 		$donation = ValidDonation::newIncompleteSofortDonation();
 		$repository = new FakeDonationRepository( $donation );
 
@@ -113,7 +113,7 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 		$request = ValidSofortNotificationRequest::newInstantPayment();
 
 		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
-		$this->assertSame( Donation::STATUS_PROMISE, $repository->getDonationById( $donation->getId() )->getStatus() );
+		$this->assertSame( Donation::STATUS_EXTERNAL_BOOKED, $repository->getDonationById( $donation->getId() )->getStatus() );
 	}
 
 	public function testWhenPaymentTypeIsNonSofort_unhandledResponseIsReturned(): void {

--- a/tests/Unit/UseCases/AddDonation/InitialDonationStatusPickerTest.php
+++ b/tests/Unit/UseCases/AddDonation/InitialDonationStatusPickerTest.php
@@ -16,8 +16,8 @@ class InitialDonationStatusPickerTest extends TestCase {
 
 		$this->assertSame( 'N', $picker( 'BEZ' ) );
 		$this->assertSame( 'Z', $picker( 'UEB' ) );
-		$this->assertSame( 'Z', $picker( 'SUB' ) );
 
+		$this->assertSame( 'X', $picker( 'SUB' ) );
 		$this->assertSame( 'X', $picker( 'MCP' ) );
 		$this->assertSame( 'X', $picker( 'foo' ) );
 	}


### PR DESCRIPTION
Sofort donations now have an initial status of "X" (unconfirmed external
donation) and get a status of "Z" (payment promise) after they are
confirmed.

This avoids unconfirmed & bogus donations from being exported.

Previously, the status of sofort donations was always "Z" (payment
promise) and the moderation status was never set because
notifyOfPolicyValidationFailure only sets the status for non-external
payments.

This is for fixing https://phabricator.wikimedia.org/T179468