### PR TITLE
PaymentMethods:: enum to PaymentMethod::

### DIFF
--- a/contexts/PaymentContext/src/Domain/Model/BankTransferPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/BankTransferPayment.php
@@ -17,7 +17,7 @@ class BankTransferPayment implements PaymentMethod {
 	}
 
 	public function getId(): string {
-		return PaymentMethods::BANK_TRANSFER;
+		return PaymentMethod::BANK_TRANSFER;
 	}
 
 	public function getBankTransferCode(): string {

--- a/contexts/PaymentContext/src/Domain/Model/CreditCardPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/CreditCardPayment.php
@@ -17,7 +17,7 @@ class CreditCardPayment implements PaymentMethod {
 	}
 
 	public function getId(): string {
-		return PaymentMethods::CREDIT_CARD;
+		return PaymentMethod::CREDIT_CARD;
 	}
 
 	public function getCreditCardData(): ?CreditCardTransactionData {

--- a/contexts/PaymentContext/src/Domain/Model/DirectDebitPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/DirectDebitPayment.php
@@ -17,7 +17,7 @@ class DirectDebitPayment implements PaymentMethod {
 	}
 
 	public function getId(): string {
-		return PaymentMethods::DIRECT_DEBIT;
+		return PaymentMethod::DIRECT_DEBIT;
 	}
 
 	public function getBankData(): BankData {

--- a/contexts/PaymentContext/src/Domain/Model/PayPalPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/PayPalPayment.php
@@ -17,7 +17,7 @@ class PayPalPayment implements PaymentMethod {
 	}
 
 	public function getId(): string {
-		return PaymentMethods::PAYPAL;
+		return PaymentMethod::PAYPAL;
 	}
 
 	public function getPayPalData(): PayPalData {

--- a/contexts/PaymentContext/src/Domain/Model/PaymentMethod.php
+++ b/contexts/PaymentContext/src/Domain/Model/PaymentMethod.php
@@ -10,8 +10,14 @@ namespace WMDE\Fundraising\Frontend\PaymentContext\Domain\Model;
  */
 interface PaymentMethod {
 
+	public const BANK_TRANSFER = 'UEB';
+	public const CREDIT_CARD = 'MCP';
+	public const DIRECT_DEBIT = 'BEZ';
+	public const PAYPAL = 'PPL';
+	public const SOFORT = 'SUB';
+
 	/**
-	 * @return string Element of the PaymentMethods:: enum
+	 * @return string Element of the PaymentMethod:: enum
 	 */
 	public function getId(): string;
 

--- a/contexts/PaymentContext/src/Domain/Model/PaymentMethods.php
+++ b/contexts/PaymentContext/src/Domain/Model/PaymentMethods.php
@@ -11,14 +11,8 @@ namespace WMDE\Fundraising\Frontend\PaymentContext\Domain\Model;
  */
 final class PaymentMethods {
 
-	public const BANK_TRANSFER = 'UEB';
-	public const CREDIT_CARD = 'MCP';
-	public const DIRECT_DEBIT = 'BEZ';
-	public const PAYPAL = 'PPL';
-	public const SOFORT = 'SUB';
-
 	public static function getList(): array {
-		return ( new \ReflectionClass( self::class ) )->getConstants();
+		return ( new \ReflectionClass( PaymentMethod::class ) )->getConstants();
 	}
 
 }

--- a/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
@@ -22,7 +22,7 @@ class SofortPayment implements PaymentMethod {
 	}
 
 	public function getId(): string {
-		return PaymentMethods::SOFORT;
+		return PaymentMethod::SOFORT;
 	}
 
 	public function getBankTransferCode(): string {

--- a/contexts/PaymentContext/tests/Unit/Domain/BankDataValidatorTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/BankDataValidatorTest.php
@@ -8,7 +8,6 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\BankDataValidator;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\IbanValidator;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\Iban;
-use WMDE\Fundraising\Frontend\Tests\Unit\Validation\ValidatorTestCase;
 use WMDE\FunValidators\ValidationResult;
 
 /**

--- a/src/DataAccess/DoctrineDonationRepository.php
+++ b/src/DataAccess/DoctrineDonationRepository.php
@@ -26,7 +26,6 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\CreditCardTransactionD
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\DirectDebitPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\Iban;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentWithoutAssociatedData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalPayment;
@@ -399,15 +398,15 @@ class DoctrineDonationRepository implements DonationRepository {
 
 	private function getPaymentMethodFromEntity( DoctrineDonation $dd ): PaymentMethod {
 		switch ( $dd->getPaymentType() ) {
-			case PaymentMethods::BANK_TRANSFER:
+			case PaymentMethod::BANK_TRANSFER:
 				return new BankTransferPayment( $dd->getBankTransferCode() );
-			case PaymentMethods::DIRECT_DEBIT:
+			case PaymentMethod::DIRECT_DEBIT:
 				return new DirectDebitPayment( $this->getBankDataFromEntity( $dd ) );
-			case PaymentMethods::PAYPAL:
+			case PaymentMethod::PAYPAL:
 				return new PayPalPayment( $this->getPayPalDataFromEntity( $dd ) );
-			case PaymentMethods::CREDIT_CARD:
+			case PaymentMethod::CREDIT_CARD:
 				return new CreditCardPayment( $this->getCreditCardDataFromEntity( $dd ) );
-			case PaymentMethods::SOFORT:
+			case PaymentMethod::SOFORT:
 				$sofortPayment = new SofortPayment( $dd->getBankTransferCode() );
 				$doctrinePayment = $dd->getPayment();
 				if ( $doctrinePayment instanceof DoctrineSofortPayment ) {

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -9,7 +9,6 @@ use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\CreditCardPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\CreditCardTransactionData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
 
 /**
  * @licence GNU GPL v2+
@@ -172,7 +171,7 @@ class Donation {
 	 * @throws RuntimeException
 	 */
 	public function cancel(): void {
-		if ( $this->getPaymentMethodId() !== PaymentMethods::DIRECT_DEBIT ) {
+		if ( $this->getPaymentMethodId() !== PaymentMethod::DIRECT_DEBIT ) {
 			throw new RuntimeException( 'Can only cancel direct debit' );
 		}
 
@@ -258,7 +257,7 @@ class Donation {
 	public function hasExternalPayment(): bool {
 		return in_array(
 			$this->getPaymentMethodId(),
-			[ PaymentMethods::PAYPAL, PaymentMethods::CREDIT_CARD, PaymentMethods::SOFORT ]
+			[ PaymentMethod::PAYPAL, PaymentMethod::CREDIT_CARD, PaymentMethod::SOFORT ]
 		);
 	}
 

--- a/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -16,7 +16,6 @@ use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationConfirmatio
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankTransferPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\DirectDebitPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentWithoutAssociatedData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalPayment;
@@ -146,13 +145,13 @@ class AddDonationUseCase {
 		$paymentType = $donationRequest->getPaymentType();
 
 		switch ( $paymentType ) {
-			case PaymentMethods::BANK_TRANSFER:
+			case PaymentMethod::BANK_TRANSFER:
 				return new BankTransferPayment( $this->transferCodeGenerator->generateTransferCode( 'W-Q-' ) );
-			case PaymentMethods::DIRECT_DEBIT:
+			case PaymentMethod::DIRECT_DEBIT:
 				return new DirectDebitPayment( $donationRequest->getBankData() );
-			case PaymentMethods::PAYPAL:
+			case PaymentMethod::PAYPAL:
 				return new PayPalPayment( new PayPalData() );
-			case PaymentMethods::SOFORT:
+			case PaymentMethod::SOFORT:
 				return new SofortPayment( $this->transferCodeGenerator->generateTransferCode( 'W-Q-' ) );
 			default:
 				return new PaymentWithoutAssociatedData( $paymentType );

--- a/src/UseCases/AddDonation/AddDonationValidator.php
+++ b/src/UseCases/AddDonation/AddDonationValidator.php
@@ -8,6 +8,7 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationVa
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\ValidateDonor\ValidateDonorRequest;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\ValidateDonor\ValidateDonorUseCase;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\BankDataValidator;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\PaymentDataValidator;
 use WMDE\FunValidators\ConstraintViolation;
@@ -82,7 +83,7 @@ class AddDonationValidator {
 	}
 
 	private function validateBankData(): void {
-		if ( $this->request->getPaymentType() !== PaymentMethods::DIRECT_DEBIT ) {
+		if ( $this->request->getPaymentType() !== PaymentMethod::DIRECT_DEBIT ) {
 			return;
 		}
 

--- a/src/UseCases/AddDonation/InitialDonationStatusPicker.php
+++ b/src/UseCases/AddDonation/InitialDonationStatusPicker.php
@@ -5,14 +5,14 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 
 class InitialDonationStatusPicker {
 
 	public function __invoke( string $paymentType ): string {
-		if ( $paymentType === PaymentMethods::DIRECT_DEBIT ) {
+		if ( $paymentType === PaymentMethod::DIRECT_DEBIT ) {
 			return Donation::STATUS_NEW;
-		} elseif ( $paymentType === PaymentMethods::BANK_TRANSFER ) {
+		} elseif ( $paymentType === PaymentMethod::BANK_TRANSFER ) {
 			return Donation::STATUS_PROMISE;
 		}
 

--- a/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
+++ b/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\StoreDonationE
 use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationConfirmationMailer;
 use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationEventLogger;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\CreditCardTransactionData;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 use WMDE\Fundraising\Frontend\PaymentContext\Infrastructure\CreditCardService;
 
 /**
@@ -57,7 +57,7 @@ class CreditCardNotificationUseCase {
 			throw new CreditCardPaymentHandlerException( 'donation not found' );
 		}
 
-		if ( $donation->getPaymentMethodId() !== PaymentMethods::CREDIT_CARD ) {
+		if ( $donation->getPaymentMethodId() !== PaymentMethod::CREDIT_CARD ) {
 			throw new CreditCardPaymentHandlerException( 'payment type mismatch' );
 		}
 

--- a/src/UseCases/ValidateDonor/ValidateDonorUseCase.php
+++ b/src/UseCases/ValidateDonor/ValidateDonorUseCase.php
@@ -4,9 +4,9 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\DonationContext\UseCases\ValidateDonor;
 
+use WMDE\Fundraising\Frontend\DonationContext\UseCases\ValidateDonor\ValidateDonorResponse as Response;
 use WMDE\FunValidators\ConstraintViolation;
 use WMDE\FunValidators\Validators\EmailValidator;
-use WMDE\Fundraising\Frontend\DonationContext\UseCases\ValidateDonor\ValidateDonorResponse as Response;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/Data/IncompleteDoctrineDonation.php
+++ b/tests/Data/IncompleteDoctrineDonation.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Data;
 
 use WMDE\Fundraising\Entities\Donation;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 
 /**
  * @licence GNU GPL v2+
@@ -33,7 +33,7 @@ class IncompleteDoctrineDonation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
-		$donation->setPaymentType( PaymentMethods::PAYPAL );
+		$donation->setPaymentType( PaymentMethod::PAYPAL );
 		$donation->setStatus( Donation::STATUS_NEW );
 
 		$donation->encodeAndSetData(
@@ -51,7 +51,7 @@ class IncompleteDoctrineDonation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
-		$donation->setPaymentType( PaymentMethods::PAYPAL );
+		$donation->setPaymentType( PaymentMethod::PAYPAL );
 		$donation->setStatus( Donation::STATUS_NEW );
 
 		$donation->encodeAndSetData(
@@ -68,7 +68,7 @@ class IncompleteDoctrineDonation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
-		$donation->setPaymentType( PaymentMethods::DIRECT_DEBIT );
+		$donation->setPaymentType( PaymentMethod::DIRECT_DEBIT );
 		$donation->setStatus( Donation::STATUS_NEW );
 
 		$donation->encodeAndSetData(
@@ -85,7 +85,7 @@ class IncompleteDoctrineDonation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
-		$donation->setPaymentType( PaymentMethods::CREDIT_CARD );
+		$donation->setPaymentType( PaymentMethod::CREDIT_CARD );
 		$donation->setStatus( Donation::STATUS_NEW );
 
 		$donation->encodeAndSetData(

--- a/tests/Data/ValidAddDonationRequest.php
+++ b/tests/Data/ValidAddDonationRequest.php
@@ -9,7 +9,7 @@ use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonorName;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\Iban;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 
 /**
  * @license GNU GPL v2+
@@ -23,7 +23,7 @@ class ValidAddDonationRequest {
 		$request->setBankData( self::newValidBankData() );
 		$request->setInterval( ValidDonation::PAYMENT_INTERVAL_IN_MONTHS );
 		$request->setOptIn( (string)ValidDonation::OPTS_INTO_NEWSLETTER );
-		$request->setPaymentType( PaymentMethods::DIRECT_DEBIT );
+		$request->setPaymentType( PaymentMethod::DIRECT_DEBIT );
 
 		$request->setDonorType( DonorName::PERSON_PRIVATE );
 		$request->setDonorSalutation( ValidDonation::DONOR_SALUTATION );

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Data;
 
 use WMDE\Fundraising\Entities\Donation;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 
 /**
  * @licence GNU GPL v2+
@@ -30,7 +30,7 @@ class ValidDoctrineDonation {
 
 		$donation->setAmount( (string)ValidDonation::DONATION_AMOUNT );
 		$donation->setPaymentIntervalInMonths( ValidDonation::PAYMENT_INTERVAL_IN_MONTHS );
-		$donation->setPaymentType( PaymentMethods::DIRECT_DEBIT );
+		$donation->setPaymentType( PaymentMethod::DIRECT_DEBIT );
 
 		$donation->setDonorCity( ValidDonation::DONOR_CITY );
 		$donation->setDonorEmail( ValidDonation::DONOR_EMAIL_ADDRESS );

--- a/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
+++ b/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
@@ -23,7 +23,7 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationVa
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationValidator;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\InitialDonationStatusPicker;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\ReferrerGeneralizer;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethods;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\TransferCodeGenerator;
 use WMDE\FunValidators\ConstraintViolation;
 
@@ -179,14 +179,14 @@ class AddDonationUseCaseTest extends TestCase {
 	private function newMinimumDonationRequest(): AddDonationRequest {
 		$donationRequest = new AddDonationRequest();
 		$donationRequest->setAmount( Euro::newFromString( '1.00' ) );
-		$donationRequest->setPaymentType( PaymentMethods::BANK_TRANSFER );
+		$donationRequest->setPaymentType( PaymentMethod::BANK_TRANSFER );
 		$donationRequest->setDonorType( DonorName::PERSON_ANONYMOUS );
 		return $donationRequest;
 	}
 
 	private function newInvalidDonationRequest(): AddDonationRequest {
 		$donationRequest = new AddDonationRequest();
-		$donationRequest->setPaymentType( PaymentMethods::DIRECT_DEBIT );
+		$donationRequest->setPaymentType( PaymentMethod::DIRECT_DEBIT );
 		$donationRequest->setAmount( Euro::newFromInt( 0 ) );
 		$donationRequest->setDonorType( DonorName::PERSON_ANONYMOUS );
 		return $donationRequest;


### PR DESCRIPTION
When I saw PaymentTpe::BankTransfer turned into PaymentMethods::BankTransfer
I firgued the plural makes less sense for such refferences so am changing
it back to how it was.