### PR TITLE
Prevent composer from using the GitHub API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "https://github.com/wmde/fundraising-payments"
+			"url": "https://github.com/wmde/fundraising-payments",
+            "no-api": true
 		}
 	],
 	"require-dev": {


### PR DESCRIPTION
We might run into API rate limits while requesting our own packages, so
we force composer to actually use the git binary to download the
packages instead of using the GitHub API.

See https://getcomposer.org/doc/05-repositories.md#vcs