### PR TITLE
Use latest major version of FundraisingStore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"psr/log": "~1.0",
 		"pimple/pimple": "~3.0",
 
-		"wmde/fundraising-store": "~10.1.1",
+		"wmde/fundraising-store": "~10.1",
 		"wmde/fundraising-payments": "@dev",
 		"wmde/euro": "~1.0",
 		"wmde/email-address": "~1.0",


### PR DESCRIPTION
Using the minor version should suffice and will ease the update pain when minor, non-BC breaking features are intoduced (as in https://github.com/wmde/FundraisingStore/pull/157)