### PR TITLE
Avoid booking of duplicate Paypal transactions

### DIFF
--- a/src/DataAccess/DoctrineDonationRepository.php
+++ b/src/DataAccess/DoctrineDonationRepository.php
@@ -227,7 +227,8 @@ class DoctrineDonationRepository implements DonationRepository {
 			'ext_payment_type' => $payPalData->getPaymentType(),
 			'ext_payment_status' => $payPalData->getPaymentStatus(),
 			'ext_payment_account' => $payPalData->getPayerId(),
-			'ext_payment_timestamp' => $payPalData->getPaymentTimestamp()
+			'ext_payment_timestamp' => $payPalData->getPaymentTimestamp(),
+			'transactionIds' => $payPalData->getAllChildPayments()
 		];
 	}
 
@@ -454,27 +455,35 @@ class DoctrineDonationRepository implements DonationRepository {
 	private function getPayPalDataFromEntity( DoctrineDonation $dd ): ?PayPalData {
 		$data = $dd->getDecodedData();
 
-		if ( array_key_exists( 'paypal_payer_id', $data ) ) {
-			return ( new PayPalData() )
-				->setPayerId( $data['paypal_payer_id'] )
-				->setSubscriberId( $data['paypal_subscr_id'] ?? '' )
-				->setPayerStatus( $data['paypal_payer_status'] ?? '' )
-				->setAddressStatus( $data['paypal_address_status'] ?? '' )
-				->setAmount( Euro::newFromString( $data['paypal_mc_gross'] ?? '0' ) )
-				->setCurrencyCode( $data['paypal_mc_currency'] ?? '' )
-				->setFee( Euro::newFromString( $data['paypal_mc_fee'] ?? '0' ) )
-				->setSettleAmount( Euro::newFromString( $data['paypal_settle_amount'] ?? '0' ) )
-				->setFirstName( $data['paypal_first_name'] ?? '' )
-				->setLastName( $data['paypal_last_name'] ?? '' )
-				->setAddressName( $data['paypal_address_name'] ?? '' )
-				->setPaymentId( $data['ext_payment_id'] ?? '' )
-				->setPaymentType( $data['ext_payment_type'] ?? '' )
-				->setPaymentStatus( $data['ext_payment_status'] ?? '' )
-				->setPaymentTimestamp( $data['ext_payment_timestamp'] ?? '' )
-				->freeze()->assertNoNullFields();
+		if ( !array_key_exists( 'paypal_payer_id', $data ) ) {
+			return null;
 		}
 
-		return null;
+		$payPalData = ( new PayPalData() )
+			->setPayerId( $data['paypal_payer_id'] )
+			->setSubscriberId( $data['paypal_subscr_id'] ?? '' )
+			->setPayerStatus( $data['paypal_payer_status'] ?? '' )
+			->setAddressStatus( $data['paypal_address_status'] ?? '' )
+			->setAmount( Euro::newFromString( $data['paypal_mc_gross'] ?? '0' ) )
+			->setCurrencyCode( $data['paypal_mc_currency'] ?? '' )
+			->setFee( Euro::newFromString( $data['paypal_mc_fee'] ?? '0' ) )
+			->setSettleAmount( Euro::newFromString( $data['paypal_settle_amount'] ?? '0' ) )
+			->setFirstName( $data['paypal_first_name'] ?? '' )
+			->setLastName( $data['paypal_last_name'] ?? '' )
+			->setAddressName( $data['paypal_address_name'] ?? '' )
+			->setPaymentId( $data['ext_payment_id'] ?? '' )
+			->setPaymentType( $data['ext_payment_type'] ?? '' )
+			->setPaymentStatus( $data['ext_payment_status'] ?? '' )
+			->setPaymentTimestamp( $data['ext_payment_timestamp'] ?? '' )
+			->freeze()->assertNoNullFields();
+
+		if ( !empty( $data['transactionIds'] ) ) {
+			foreach ( $data['transactionIds'] as $transactionId => $entityId ) {
+				$payPalData->addChildPayment( $transactionId, (int) $entityId );
+			}
+		}
+
+		return $payPalData;
 	}
 
 	private function getCreditCardDataFromEntity( DoctrineDonation $dd ): CreditCardTransactionData {

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -30,6 +30,19 @@ class ValidDoctrineDonation {
 		return $donation;
 	}
 
+	public static function newPaypalDoctrineDonation(): Donation {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setPaymentType( PaymentMethod::PAYPAL );
+		$donation->encodeAndSetData(
+			array_merge(
+				$donation->getDecodedData(),
+				$self->getPaypalDataArray()
+			)
+		);
+		return $donation;
+	}
+
 	private function createDonation(): Donation {
 		$donation = new Donation();
 
@@ -104,6 +117,26 @@ class ValidDoctrineDonation {
 			'plz' => ValidDonation::DONOR_POSTAL_CODE,
 			'ort' => ValidDonation::DONOR_CITY,
 			'country' => ValidDonation::DONOR_COUNTRY_CODE,
+		];
+	}
+
+	private function getPaypalDataArray(): array {
+		return [
+			'ext_payment_id' => '72171T32A6H345906',
+			'ext_subscr_id' => 'I-DYP3HRBE7WUA',
+			'ext_payment_status' => 'Completed/subscr_payment',
+			'ext_payment_account' => 'QEEMF34KV3ECL',
+			'ext_payment_type' => 'instant',
+			'ext_payment_timestamp' => '05:10:30 May 17, 2016 PDT',
+			'paypal_payer_id' => 'QEEMF34KV3ECL',
+			'paypal_subscr_id' => 'I-DYP3HRBE7WUA',
+			'paypal_payer_status' => 'verified',
+			'paypal_first_name' => 'Max',
+			'paypal_last_name' => 'Muster',
+			'paypal_mc_gross' => '10.00',
+			'paypal_mc_currency' => 'EUR',
+			'paypal_mc_fee' => '0.47',
+			'user_agent' => 'PayPal IPN ( https://www.paypal.com/ipn )',
 		];
 	}
 

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -96,9 +96,9 @@ class ValidDonation {
 		);
 	}
 
-	public static function newBookedPayPalDonation(): Donation {
+	public static function newBookedPayPalDonation( string $transactionId = self::PAYPAL_TRANSACTION_ID ): Donation {
 		$payPalData = new PayPalData();
-		$payPalData->setPaymentId( self::PAYPAL_TRANSACTION_ID );
+		$payPalData->setPaymentId( $transactionId );
 
 		return ( new self() )->createDonation(
 			new PayPalPayment( $payPalData ),

--- a/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -241,6 +241,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 					'paypal_settle_amount' => '1.23',
 					'paypal_address_name' => 'Max Muster',
 					'paypal_address_status' => 'unconfirmed',
+					'transactionIds' => [],
 
 					// these values were stored as strings
 					'impCount' => 0,
@@ -300,6 +301,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 					'paypal_settle_amount' => '1.23',
 					'paypal_address_name' => 'Max Muster',
 					'paypal_address_status' => 'unconfirmed',
+					'transactionIds' => [],
 
 					// these values were stored as strings
 					'impCount' => 0,


### PR DESCRIPTION
Track child transactions when loading and saving Donations in
DoctrineDonationRepository.

Change logic in Paypal notification processing as follows:

1. Check if a transaction ID was already booked and if yes, don't
   process it again. Check the donation itself and its "child" donations
   (for recurring donations).
2. If the donation is already booked (with a different transaction ID,
   implicit through the previous check) and it's recurring, then book
   the transaction as a "child" donation.