### PR TITLE
Change deprecated assertions

### DIFF
--- a/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
@@ -338,7 +338,7 @@ class HandlePayPalPaymentCompletionNotificationUseCaseTest extends TestCase {
 
 		$this->assertFalse( $result->notificationWasHandled() );
 		$this->assertNotEmpty( $result->getContext()['message'] );
-		$this->assertContains( 'already booked', $result->getContext()['message'] );
+		$this->assertStringContainsString( 'already booked', $result->getContext()['message'] );
 	}
 
 	public function testGivenTransactionIdInBookedChildDonation_notificationIsNotHandled(): void {
@@ -360,7 +360,7 @@ class HandlePayPalPaymentCompletionNotificationUseCaseTest extends TestCase {
 
 		$this->assertFalse( $result->notificationWasHandled() );
 		$this->assertNotEmpty( $result->getContext()['message'] );
-		$this->assertContains( 'already booked', $result->getContext()['message'] );
+		$this->assertStringContainsString( 'already booked', $result->getContext()['message'] );
 	}
 
 	public function testWhenNotificationIsForNonExistingDonation_newDonationIsCreated(): void {

--- a/tests/Unit/Domain/Model/DonationTest.php
+++ b/tests/Unit/Domain/Model/DonationTest.php
@@ -105,7 +105,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$this->expectException( RuntimeException::class );
-		$this->expectExceptionMessageRegExp( '/Only external payments/' );
+		$this->expectExceptionMessageMatches( '/Only external payments/' );
 		$donation->confirmBooked();
 	}
 


### PR DESCRIPTION
Change assertion names that were deprecated in PHPUnit 8.

This is a followup for #83