### PR TITLE
Make dtExp getter and setter nullable

### DIFF
--- a/src/DataAccess/DoctrineEntities/Donation.php
+++ b/src/DataAccess/DoctrineEntities/Donation.php
@@ -434,13 +434,13 @@ class Donation {
 		return $this->deletionTime;
 	}
 
-	public function setDtExp( \DateTime $dtExp ): self {
+	public function setDtExp( ?\DateTime $dtExp ): self {
 		$this->dtExp = $dtExp;
 
 		return $this;
 	}
 
-	public function getDtExp(): \DateTime {
+	public function getDtExp(): ?\DateTime {
 		return $this->dtExp;
 	}
 


### PR DESCRIPTION
This is to fix tests in the Fundraising Backend.