### PR TITLE
Made donor email nullable

### DIFF
--- a/src/DataAccess/DoctrineEntities/Donation.php
+++ b/src/DataAccess/DoctrineEntities/Donation.php
@@ -236,7 +236,7 @@ class Donation {
 		return $this;
 	}
 
-	public function getDonorEmail(): string {
+	public function getDonorEmail(): ?string {
 		return $this->donorEmail;
 	}
 


### PR DESCRIPTION
This is to prevent php strict errors being thrown in fundraising backend, because on anonymous donations the field can be null in the database