### PR TITLE
Make donor fullname nullable

### DIFF
--- a/src/DataAccess/DoctrineEntities/Donation.php
+++ b/src/DataAccess/DoctrineEntities/Donation.php
@@ -223,7 +223,7 @@ class Donation {
 		return $this;
 	}
 
-	public function getDonorFullName(): string {
+	public function getDonorFullName(): ?string {
 		return $this->donorFullName;
 	}
 


### PR DESCRIPTION
This fixes a null entry being returned in the Fun Ops center