### PR TITLE
Fix loading anonymized PayPal donations

### DIFF
--- a/src/DataAccess/DataReaderWithDefault.php
+++ b/src/DataAccess/DataReaderWithDefault.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess;
+
+class DataReaderWithDefault {
+	private array $data;
+
+	public function __construct( array $data ) {
+		$this->data = $data;
+	}
+
+	public function getValue( string $key ): string {
+		return $this->data[$key] ?? '';
+	}
+}

--- a/src/DataAccess/DonorFieldMapper.php
+++ b/src/DataAccess/DonorFieldMapper.php
@@ -9,9 +9,6 @@ use WMDE\Fundraising\DonationContext\Domain\Model\Address;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Address\NoAddress;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
-use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\CompanyName;
-use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\NoName;
-use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\PersonName;
 use WMDE\Fundraising\DonationContext\Domain\Model\DonorName;
 
 /**

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -75,7 +75,7 @@ class ValidDoctrineDonation {
 		return $donation;
 	}
 
-	public static function newEmailDonation() {
+	public static function newEmailDonation(): Donation {
 		$self = new self();
 		$donation = $self->createDonation();
 		$donation->setPaymentType( PaymentMethod::PAYPAL );
@@ -90,6 +90,24 @@ class ValidDoctrineDonation {
 				$self->getPaypalDataArray()
 			)
 		);
+		return $donation;
+	}
+
+	public static function newAnyonymizedDonation() {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setPaymentType( PaymentMethod::PAYPAL );
+		$donation->encodeAndSetData(
+			array_merge(
+				[
+					'adresstyp' => 'person',
+				],
+				$self->getTrackingInfoArray(),
+				$self->getPaypalDataArray()
+			)
+		);
+		$donation->setDonorCity( '' );
+		$donation->setDonorEmail( '' );
 		return $donation;
 	}
 

--- a/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationRepository;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation as DoctrineDonation;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
-use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\StoreDonationException;
 use WMDE\Fundraising\DonationContext\Tests\Data\IncompleteDoctrineDonation;

--- a/tests/Unit/DataAccess/DonorFactoryTest.php
+++ b/tests/Unit/DataAccess/DonorFactoryTest.php
@@ -43,6 +43,13 @@ class DonorFactoryTest extends TestCase {
 		$this->assertEquals( ValidDonation::newEmailOnlyDonor(), $donor );
 	}
 
+	public function testCreatePrivateAnonymizedDonor(): void {
+		$donor = DonorFactory::createDonorFromEntity( ValidDoctrineDonation::newAnyonymizedDonation() );
+
+		$this->assertInstanceOf( PersonDonor::class, $donor );
+		$this->assertSame( '', $donor->getName()->getFullName() );
+	}
+
 	public function testUnknownAddressTypeThrowsException(): void {
 		$doctrineDonation = ValidDoctrineDonation::newAnonymousDonation();
 		$doctrineDonation->encodeAndSetData( [ 'adresstyp' => 'unknown' ] );


### PR DESCRIPTION
The refactoring done in #101 introduced stricter type checks when
creating donors from the database BLOB. This lead to type errors when we
were loading anonymized donations for recurring PayPal payments, because
our anonymization code deletes the fields from the BLOB, making them
`null` instead of empty strings.

This change introduces a wrapper for those values, always initializing
anonymized donors with the correct donor type, but with empty strings.

This wrapper is a stopgap measure until we refactor the database schema
(See https://phabricator.wikimedia.org/T203679), where these cases would
be handled by a more targeted database model that only loads required
data and implements the concept of an "anonymized donation" better