### PR TITLE
Add use case for Comment approval

### DIFF
--- a/src/DataAccess/LegacyCommentRepository.php
+++ b/src/DataAccess/LegacyCommentRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess;
+
+use WMDE\Fundraising\DonationContext\Domain\Model\DonationComment;
+use WMDE\Fundraising\DonationContext\Domain\Repositories\CommentRepository;
+use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationRepository;
+use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
+
+/**
+ * This class is an implementation of the CommentRepository using the legacy
+ * database schema where comments are part of the donation table.
+ *
+ * This class should be replaced with an implementation that's more independent
+ * from the DonationRepository. See https://phabricator.wikimedia.org/T203679
+ */
+class LegacyCommentRepository implements CommentRepository {
+
+	private array $fetchedComments = [];
+	private DonationRepository $donationRepository;
+
+	public function __construct( DonationRepository $donationRepository ) {
+ $this->donationRepository = $donationRepository;
+	}
+
+	public function getCommentById( int $commentId ): ?DonationComment {
+		throw new LegacyException( 'getCommentById not implementable with legacy data base schema' );
+	}
+
+	public function getCommentByDonationId( int $donationId ): ?DonationComment {
+		$donation = $this->donationRepository->getDonationById( $donationId );
+		if ( $donation === null ) {
+			throw new GetDonationException();
+		}
+		$comment = $donation->getComment();
+		if ( $comment !== null ) {
+			$this->fetchedComments[spl_object_id( $comment )] = $donation->getId();
+		}
+		return $comment;
+	}
+
+	public function insertCommentForDonation( int $donationId, DonationComment $comment ): int {
+		$donation = $this->donationRepository->getDonationById( $donationId );
+		if ( $donation === null ) {
+			throw new GetDonationException();
+		}
+		$donation->addComment( $comment );
+		$this->donationRepository->storeDonation( $donation );
+		// We fake the comment ID by returning the donation id. The calling code must NOT rely on that!
+		return intval( $donation->getId() );
+	}
+
+	public function updateComment( DonationComment $comment ): void {
+		$objectId = spl_object_id( $comment );
+		if ( !isset( $this->fetchedComments[$objectId] ) ) {
+			throw new LegacyException( 'updateComment is not implementable without calling getCommentByDonationId first. Please check your call order and make sure you\'re only updating donations that previously had a comment.' );
+		}
+	}
+
+}

--- a/src/DataAccess/LegacyException.php
+++ b/src/DataAccess/LegacyException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess;
+
+class LegacyException extends \LogicException {
+
+}

--- a/src/Domain/Model/DonationComment.php
+++ b/src/Domain/Model/DonationComment.php
@@ -6,13 +6,12 @@ namespace WMDE\Fundraising\DonationContext\Domain\Model;
 
 /**
  * @license GPL-2.0-or-later
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DonationComment {
 
-	private $commentText;
-	private $isPublic;
-	private $authorDisplayName;
+	private string $commentText;
+	private bool $isPublic;
+	private string $authorDisplayName;
 
 	public function __construct( string $commentText, bool $isPublic, string $authorDisplayName ) {
 		$this->commentText = $commentText;
@@ -32,4 +31,11 @@ class DonationComment {
 		return $this->isPublic;
 	}
 
+	public function publish(): void {
+		$this->isPublic = true;
+	}
+
+	public function retract(): void {
+		$this->isPublic = false;
+	}
 }

--- a/src/Domain/Repositories/CommentRepository.php
+++ b/src/Domain/Repositories/CommentRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WMDE\Fundraising\DonationContext\Domain\Repositories;
+
+use WMDE\Fundraising\DonationContext\Domain\Model\DonationComment;
+
+interface CommentRepository {
+	public function getCommentById( int $commentId ): ?DonationComment;
+
+	/**
+	 * @param int $donationId
+	 *
+	 * @return DonationComment|null
+	 * @throws GetDonationException
+	 * @deprecated Use getCommentById when https://phabricator.wikimedia.org/T203679 is done
+	 */
+	public function getCommentByDonationId( int $donationId ): ?DonationComment;
+
+	/**
+	 * @param int $donationId
+	 * @param DonationComment $comment
+	 *
+	 * @return int Comment Id
+	 * @throws GetDonationException
+	 */
+	public function insertCommentForDonation( int $donationId, DonationComment $comment ): int;
+
+	public function updateComment( DonationComment $comment ): void;
+}

--- a/src/UseCases/ModerateComment/ModerateCommentErrorResponse.php
+++ b/src/UseCases/ModerateComment/ModerateCommentErrorResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\UseCases\ModerateComment;
+
+class ModerateCommentErrorResponse implements ModerateCommentResponse {
+
+	public const ERROR_DONATION_NOT_FOUND = 'donation_not_found';
+	public const ERROR_DONATION_HAS_NO_COMMENT = 'donation_has_no_comment';
+
+	private string $error;
+
+	public function __construct( string $error ) {
+		$this->error = $error;
+	}
+
+	public function getError(): string {
+		return $this->error;
+	}
+}

--- a/src/UseCases/ModerateComment/ModerateCommentRequest.php
+++ b/src/UseCases/ModerateComment/ModerateCommentRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\UseCases\ModerateComment;
+
+class ModerateCommentRequest {
+	private const ACTION_PUBLISH = 'publish';
+	private const ACTION_RETRACT = 'retract';
+
+	private int $donationId;
+	private string $action;
+	private string $authorizedUser;
+
+	private function __construct( int $donationId, string $authorizedUser, string $action ) {
+		$this->donationId = $donationId;
+		$this->authorizedUser = $authorizedUser;
+		$this->action = $action;
+	}
+
+	public static function publishComment( int $donationId, string $authorizedUser ): self {
+		return new self( $donationId, $authorizedUser, self::ACTION_PUBLISH );
+	}
+
+	public static function retractComment( int $donationId, string $authorizedUser ): self {
+		return new self( $donationId, $authorizedUser, self::ACTION_RETRACT );
+	}
+
+	public function getDonationId(): int {
+		return $this->donationId;
+	}
+
+	public function shouldPublish(): bool {
+		return $this->action === self::ACTION_PUBLISH;
+	}
+
+	public function getAuthorizedUser(): string {
+		return $this->authorizedUser;
+	}
+}

--- a/src/UseCases/ModerateComment/ModerateCommentResponse.php
+++ b/src/UseCases/ModerateComment/ModerateCommentResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\UseCases\ModerateComment;
+
+/**
+ * @deprecated Use union type instead of marker when we have updated to PHP 8
+ */
+interface ModerateCommentResponse {
+}

--- a/src/UseCases/ModerateComment/ModerateCommentSuccessResponse.php
+++ b/src/UseCases/ModerateComment/ModerateCommentSuccessResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\UseCases\ModerateComment;
+
+class ModerateCommentSuccessResponse implements ModerateCommentResponse {
+	private int $donationId;
+
+	public function __construct( int $donationId ) {
+		$this->donationId = $donationId;
+	}
+
+	public function getDonationId(): int {
+		return $this->donationId;
+	}
+}

--- a/src/UseCases/ModerateComment/ModerateCommentUseCase.php
+++ b/src/UseCases/ModerateComment/ModerateCommentUseCase.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\UseCases\ModerateComment;
+
+use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationRepository;
+use WMDE\Fundraising\DonationContext\Infrastructure\DonationEventLogger;
+
+class ModerateCommentUseCase {
+
+	private const PUBLISH_LOG_MESSAGE = 'Comment published by user: %s';
+	private const RETRACT_LOG_MESSAGE = 'Comment set to private by user: %s';
+
+	private DonationRepository $repository;
+	private DonationEventLogger $donationEventLogger;
+
+	public function __construct( DonationRepository $repository, DonationEventLogger $donationEventLogger ) {
+		$this->repository = $repository;
+		$this->donationEventLogger = $donationEventLogger;
+	}
+
+	/**
+	 * @param ModerateCommentRequest $moderateCommentRequest
+	 *
+	 * @return ModerateCommentErrorResponse|ModerateCommentSuccessResponse
+	 */
+	public function moderateComment( ModerateCommentRequest $moderateCommentRequest ): ModerateCommentResponse {
+		$donation = $this->repository->getDonationById( $moderateCommentRequest->getDonationId() );
+		if ( $donation === null ) {
+			return new ModerateCommentErrorResponse( ModerateCommentErrorResponse::ERROR_DONATION_NOT_FOUND );
+		}
+		$comment = $donation->getComment();
+		if ( $comment === null ) {
+			return new ModerateCommentErrorResponse( ModerateCommentErrorResponse::ERROR_DONATION_HAS_NO_COMMENT );
+		}
+
+		if ( $moderateCommentRequest->shouldPublish() ) {
+			$comment->publish();
+			$logMessage = self::PUBLISH_LOG_MESSAGE;
+		} else {
+			$comment->retract();
+			$logMessage = self::RETRACT_LOG_MESSAGE;
+		}
+		$this->repository->storeDonation( $donation );
+
+		$this->donationEventLogger->log(
+			$moderateCommentRequest->getDonationId(),
+			sprintf( $logMessage, $moderateCommentRequest->getAuthorizedUser() )
+		);
+
+		return new ModerateCommentSuccessResponse( $moderateCommentRequest->getDonationId() );
+	}
+
+}

--- a/tests/Unit/Domain/Model/DonationCommentTest.php
+++ b/tests/Unit/Domain/Model/DonationCommentTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WMDE\Fundraising\DonationContext\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonationComment;
+
+/**
+ * @covers \WMDE\Fundraising\DonationContext\Domain\Model\DonationComment
+ */
+class DonationCommentTest extends TestCase {
+	public function testCreateComment(): void {
+		$commentText = 'My heartfelt thanks!';
+		$name = 'Donnie Donor';
+		$comment = new DonationComment( $commentText, true, $name );
+
+		$this->assertSame( $commentText, $comment->getCommentText() );
+		$this->assertTrue( $comment->isPublic() );
+		$this->assertSame( $name, $comment->getAuthorDisplayName() );
+	}
+
+	public function testCommentCanBePublished(): void {
+		$comment = new DonationComment( 'Greetings from Scunthorpe', false, 'Johnny English' );
+
+		$comment->publish();
+
+		$this->assertTrue( $comment->isPublic() );
+	}
+
+	public function testCommentCanBeRetracted(): void {
+		$comment = new DonationComment(
+			'I just got my PhD with content copied from Wikipedia, now it\'s time to give back',
+			true,
+			'Dr. Paul Politician'
+		);
+
+		$comment->retract();
+
+		$this->assertFalse( $comment->isPublic() );
+	}
+
+}

--- a/tests/Unit/UseCases/ModerateComment/ModerateCommentUseCaseTest.php
+++ b/tests/Unit/UseCases/ModerateComment/ModerateCommentUseCaseTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace WMDE\Fundraising\DonationContext\Tests\Unit\UseCases\ModerateComment;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonationComment;
+use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\DonationEventLoggerSpy;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\DonationRepositorySpy;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\FakeDonationRepository;
+use WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentErrorResponse;
+use WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentRequest;
+use WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentSuccessResponse;
+use WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentUseCase;
+
+/**
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentUseCase
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentRequest
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentSuccessResponse
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\ModerateComment\ModerateCommentErrorResponse
+ */
+class ModerateCommentUseCaseTest extends TestCase {
+
+	private const AUTHORIZED_USER_NAME = 'MarkusTheModerator';
+
+	public function testWhenDonationIsNotFound_moderationFails(): void {
+		$repository = new FakeDonationRepository();
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$request = ModerateCommentRequest::publishComment( 1, self::AUTHORIZED_USER_NAME );
+
+		$response = $useCase->moderateComment( $request );
+
+		$this->assertInstanceOf( ModerateCommentErrorResponse::class, $response );
+		$this->assertSame( ModerateCommentErrorResponse::ERROR_DONATION_NOT_FOUND, $response->getError() );
+	}
+
+	public function testWhenDonationHasNoComment_moderationFails(): void {
+		$donation = ValidDonation::newDirectDebitDonation();
+		$repository = new FakeDonationRepository( $donation );
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$request = ModerateCommentRequest::publishComment( $donation->getId(), self::AUTHORIZED_USER_NAME );
+
+		$response = $useCase->moderateComment( $request );
+
+		$this->assertInstanceOf( ModerateCommentErrorResponse::class, $response );
+		$this->assertSame( ModerateCommentErrorResponse::ERROR_DONATION_HAS_NO_COMMENT, $response->getError() );
+	}
+
+	/**
+	 * @dataProvider commentProviderForPublication
+	 */
+	public function testWhenDonationHasComment_publicationSucceeds( DonationComment $comment, string $assertMessage ): void {
+		$donation = ValidDonation::newDirectDebitDonation();
+		$donation->addComment( $comment );
+		$repository = new FakeDonationRepository( $donation );
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$request = ModerateCommentRequest::publishComment( $donation->getId(), self::AUTHORIZED_USER_NAME );
+
+		$response = $useCase->moderateComment( $request );
+
+		$this->assertInstanceOf( ModerateCommentSuccessResponse::class, $response );
+		$this->assertSame( $donation->getId(), $response->getDonationId() );
+		$this->assertTrue( $donation->getComment()->isPublic(), $assertMessage );
+	}
+
+	public function commentProviderForPublication(): iterable {
+		yield [ $this->newPrivateComment(), 'private comments should be published' ];
+		yield [ $this->newPublicComment(), 'public comments should stay published' ];
+	}
+
+	public function testWhenPublicationSucceeds_donationGetsPersisted(): void {
+		$donation = ValidDonation::newDirectDebitDonation();
+		$donation->addComment( $this->newPrivateComment() );
+		$repository = new DonationRepositorySpy( $donation );
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$request = ModerateCommentRequest::publishComment( $donation->getId(), self::AUTHORIZED_USER_NAME );
+
+		$response = $useCase->moderateComment( $request );
+
+		$this->assertInstanceOf( ModerateCommentSuccessResponse::class, $response );
+		$storedDonations = $repository->getStoreDonationCalls();
+		$this->assertCount( 1, $storedDonations );
+		$this->assertSame( $donation->getId(), $storedDonations[0]->getId() );
+	}
+
+	/**
+	 * @dataProvider commentProviderForRetraction
+	 */
+	public function testWhenDonationHasComment_retractionSucceeds( DonationComment $comment, string $assertMessage ): void {
+		$donation = ValidDonation::newDirectDebitDonation();
+		$donation->addComment( $comment );
+		$repository = new FakeDonationRepository( $donation );
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$request = ModerateCommentRequest::retractComment( $donation->getId(), self::AUTHORIZED_USER_NAME );
+
+		$response = $useCase->moderateComment( $request );
+
+		$this->assertInstanceOf( ModerateCommentSuccessResponse::class, $response );
+		$this->assertSame( $donation->getId(), $response->getDonationId() );
+		$this->assertFalse( $donation->getComment()->isPublic(), $assertMessage );
+	}
+
+	public function commentProviderForRetraction(): iterable {
+		yield [ $this->newPrivateComment(), 'private comments should stay private' ];
+		yield [ $this->newPublicComment(), 'public comments should be retracted' ];
+	}
+
+	public function testWhenRetractionSucceeds_donationGetsPersisted(): void {
+		$donation = ValidDonation::newDirectDebitDonation();
+		$donation->addComment( $this->newPublicComment() );
+		$repository = new DonationRepositorySpy( $donation );
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$request = ModerateCommentRequest::retractComment( $donation->getId(), self::AUTHORIZED_USER_NAME );
+
+		$response = $useCase->moderateComment( $request );
+
+		$this->assertInstanceOf( ModerateCommentSuccessResponse::class, $response );
+		$storedDonations = $repository->getStoreDonationCalls();
+		$this->assertCount( 1, $storedDonations );
+		$this->assertSame( $donation->getId(), $storedDonations[0]->getId() );
+	}
+
+	public function testPublicationAndRetractionLogAdminUserName(): void {
+		$donation = ValidDonation::newDirectDebitDonation();
+		$donation->addComment( $this->newPublicComment() );
+		$repository = new DonationRepositorySpy( $donation );
+		$logger = new DonationEventLoggerSpy();
+		$useCase = new ModerateCommentUseCase( $repository, $logger );
+		$donationId = $donation->getId();
+		$retractionRequest = ModerateCommentRequest::retractComment( $donationId, self::AUTHORIZED_USER_NAME );
+		$publicationRequest = ModerateCommentRequest::publishComment( $donationId, 'OliverTheOverrider' );
+
+		$useCase->moderateComment( $retractionRequest );
+		$useCase->moderateComment( $publicationRequest );
+
+		$logCalls = $logger->getLogCalls();
+		$this->assertCount( 2, $logCalls );
+		$expectedLogCalls = [
+			[ $donationId, 'Comment set to private by user: MarkusTheModerator' ],
+			[ $donationId, 'Comment published by user: OliverTheOverrider' ],
+		];
+		$this->assertEquals( $expectedLogCalls, $logCalls );
+	}
+
+	private function newPublicComment(): DonationComment {
+		return new DonationComment( 'I love Wikipedia', true, 'Donnie Donor' );
+	}
+
+	private function newPrivateComment(): DonationComment {
+		return new DonationComment( 'I donated for Wikipedia and all I got is this confirmation T-Shirt', false, 'anonymous' );
+	}
+}


### PR DESCRIPTION
* Add a repository for loading and storing comments (not fully independent from donations yet, but a preparation for https://phabricator.wikimedia.org/T203679)
* Add a use case for showing and hiding comments. The return type demonstrates how new use cases should use union types if they need to return different data depending on success or failure.

This is part of https://phabricator.wikimedia.org/T276817