### PR TITLE
Add HttpDonationConfirmationNotifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 		"doctrine/orm": "~2.7",
 		"gedmo/doctrine-extensions": "^3.0",
 		"psr/log": "~1.0",
+		"symfony/http-client": "^5.2",
 
 		"wmde/email-address": "~1.0",
 		"wmde/euro": "~1.0",

--- a/src/Authorization/DonationAuthorizer.php
+++ b/src/Authorization/DonationAuthorizer.php
@@ -37,4 +37,11 @@ interface DonationAuthorizer {
 	 */
 	public function canAccessDonation( int $donationId ): bool;
 
+	/**
+	 * @param int $donationId
+	 *
+	 * @return TokenSet
+	 */
+	public function getTokensForDonation( int $donationId ): TokenSet;
+
 }

--- a/src/Authorization/TokenSet.php
+++ b/src/Authorization/TokenSet.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\Authorization;
+
+/**
+ * TokenSet can be used to create authorization URL parameters for accessing donations.
+ */
+class TokenSet {
+
+	private string $updateToken;
+	private string $accessToken;
+
+	public function __construct( string $updateToken, string $accessToken ) {
+		$this->updateToken = $updateToken;
+		$this->accessToken = $accessToken;
+	}
+
+	public function getUpdateToken(): string {
+		return $this->updateToken;
+	}
+
+	public function getAccessToken(): string {
+		return $this->accessToken;
+	}
+
+}

--- a/src/Infrastructure/HttpDonationConfirmationNotifier.php
+++ b/src/Infrastructure/HttpDonationConfirmationNotifier.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\Infrastructure;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
+use WMDE\Fundraising\DonationContext\UseCases\DonationConfirmationNotifier;
+
+/**
+ * @license GPL-2.0-or-later
+ */
+class HttpDonationConfirmationNotifier implements DonationConfirmationNotifier {
+
+	private DonationAuthorizer $authorizer;
+	private HttpClientInterface $httpClient;
+	private string $endpointUrl;
+
+	public function __construct( DonationAuthorizer $authorizer, HttpClientInterface $httpClient, string $endpointUrl ) {
+		$this->authorizer = $authorizer;
+		$this->httpClient = $httpClient;
+		$this->endpointUrl = $endpointUrl;
+	}
+
+	public function sendConfirmationFor( Donation $donation ): void {
+		$this->httpClient->request(
+			'GET',
+			$this->endpointUrl,
+			[ 'query' => [
+				'donation_id' => $donation->getId(),
+				'update_token' => $this->authorizer->getTokensForDonation( $donation->getId() )->getUpdateToken()
+			] ]
+		);
+	}
+
+}

--- a/tests/Fixtures/FailingDonationAuthorizer.php
+++ b/tests/Fixtures/FailingDonationAuthorizer.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
 use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
+use WMDE\Fundraising\DonationContext\Authorization\TokenSet;
 
 /**
  * @license GPL-2.0-or-later
@@ -24,4 +25,7 @@ class FailingDonationAuthorizer implements DonationAuthorizer {
 		return false;
 	}
 
+	public function getTokensForDonation( int $donationId ): TokenSet {
+		throw new \RuntimeException( 'no donation found' );
+	}
 }

--- a/tests/Fixtures/SucceedingDonationAuthorizer.php
+++ b/tests/Fixtures/SucceedingDonationAuthorizer.php
@@ -4,13 +4,21 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
+use TheSeer\Tokenizer\Token;
 use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
+use WMDE\Fundraising\DonationContext\Authorization\TokenSet;
 
 /**
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SucceedingDonationAuthorizer implements DonationAuthorizer {
+
+	private TokenSet $tokenSet;
+
+	public function __construct() {
+		$this->tokenSet = new TokenSet( '~succeeding update token~', '~succeeding access token~' );
+	}
 
 	public function userCanModifyDonation( int $donationId ): bool {
 		return true;
@@ -24,4 +32,11 @@ class SucceedingDonationAuthorizer implements DonationAuthorizer {
 		return true;
 	}
 
+	public function getTokensForDonation( int $donationId ): TokenSet {
+		return $this->tokenSet;
+	}
+
+	public function setTokenSet( TokenSet $tokenSet ): void {
+		$this->tokenSet = $tokenSet;
+	}
 }

--- a/tests/Fixtures/SucceedingDonationAuthorizerSpy.php
+++ b/tests/Fixtures/SucceedingDonationAuthorizerSpy.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
 use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
+use WMDE\Fundraising\DonationContext\Authorization\TokenSet;
 
 /**
  * @license GPL-2.0-or-later
@@ -37,4 +38,7 @@ class SucceedingDonationAuthorizerSpy implements DonationAuthorizer {
 		return $this->authorizedAsAdmin;
 	}
 
+	public function getTokensForDonation( int $donationId ): TokenSet {
+		throw new \LogicException( 'not needed yet, implement when needed' );
+	}
 }

--- a/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationAuthorizer;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation;
+use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\DonationContext\Tests\TestEnvironment;
 
 /**
@@ -220,6 +221,59 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 			->willThrowException( new ORMException() );
 
 		return $entityManager;
+	}
+
+	public function testGivenExistingDonation_AuthorizerReturnsTokenSet(): void {
+		$donation = new Donation();
+		$donationData = $donation->getDataObject();
+		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
+		$donationData->setAccessToken( self::CORRECT_ACCESS_TOKEN );
+		$donation->setDataObject( $donationData );
+		$this->storeDonation( $donation );
+
+		$donAuthorizer = new DoctrineDonationAuthorizer( $this->entityManager );
+		$resultTokenSet = $donAuthorizer->getTokensForDonation( $donation->getId() );
+
+		$this->assertSame( self::CORRECT_ACCESS_TOKEN, $resultTokenSet->getAccessToken() );
+		$this->assertSame( self::CORRECT_UPDATE_TOKEN, $resultTokenSet->getUpdateToken() );
+	}
+
+	public function testGivenDonationWithMissingAccessToken_AuthorizerThrowsException(): void {
+		$donation = new Donation();
+		$donationData = $donation->getDataObject();
+		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
+		$donation->setDataObject( $donationData );
+		$mockEM = $this->createMock( EntityManager::class );
+		$mockEM->method( 'find' )->willReturn( $donation );
+
+		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM );
+
+		$this->expectException( \UnexpectedValueException::class );
+		$donAuthorizer->getTokensForDonation( self::MEANINGLESS_DONATION_ID );
+	}
+
+	public function testGivenDonationWithMissingUpdateToken_AuthorizerThrowsException(): void {
+		$donation = new Donation();
+		$donationData = $donation->getDataObject();
+		$donationData->setAccessToken( self::CORRECT_ACCESS_TOKEN );
+		$donation->setDataObject( $donationData );
+		$mockEM = $this->createMock( EntityManager::class );
+		$mockEM->method( 'find' )->willReturn( $donation );
+
+		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM );
+
+		$this->expectException( \UnexpectedValueException::class );
+		$donAuthorizer->getTokensForDonation( self::MEANINGLESS_DONATION_ID );
+	}
+
+	public function testGivenMissingDonation_AuthorizerThrowsException(): void {
+		$mockEM = $this->createMock( EntityManager::class );
+		$mockEM->method( 'find' )->willReturn( null );
+
+		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM );
+
+		$this->expectException( GetDonationException::class );
+		$donAuthorizer->getTokensForDonation( self::MEANINGLESS_DONATION_ID );
 	}
 
 }

--- a/tests/Unit/Infrastructure/HttpDonationConfirmationNotifierTest.php
+++ b/tests/Unit/Infrastructure/HttpDonationConfirmationNotifierTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WMDE\Fundraising\DonationContext\Tests\Unit\Infrastructure;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use WMDE\Fundraising\DonationContext\Authorization\TokenSet;
+use WMDE\Fundraising\DonationContext\Infrastructure\HttpDonationConfirmationNotifier;
+use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\SucceedingDonationAuthorizer;
+
+/**
+ * @covers \WMDE\Fundraising\DonationContext\Infrastructure\HttpDonationConfirmationNotifier
+ */
+class HttpDonationConfirmationNotifierTest extends TestCase {
+
+	public function testSendConfirmationFor(): void {
+		$donation = ValidDonation::newBookedAnonymousPayPalDonationUpdate( 1 );
+		$testToken = 'blabla';
+		$httpClient = $this->createMock( HttpClientInterface::class );
+		$authorizer = new SucceedingDonationAuthorizer();
+		$authorizer->setTokenSet( new TokenSet( $testToken, "random value token" ) );
+		$endpointUrl = 'https://somefancyendpoint.xyz/';
+
+		$httpClient->expects( $this->once() )->method( 'request' )->with(
+			'GET',
+			$endpointUrl,
+			[ 'query' => [
+				'donation_id' => $donation->getId(),
+				'update_token' => $testToken
+			] ]
+		);
+
+		$notifier = new HttpDonationConfirmationNotifier( $authorizer, $httpClient, $endpointUrl );
+		$notifier->sendConfirmationFor( $donation );
+	}
+}


### PR DESCRIPTION
- implements DonationConfirmationNotifier
- calls http endpoint instead of sending mails directly

- reason:
  We don't have templates set up in the FOC (fundraising operation center) and need to
relay the sending of mails to the fundraising app.

Related to this ticket:
https://phabricator.wikimedia.org/T276820