### PR TITLE
Add missing state conversion

### DIFF
--- a/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
+++ b/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
@@ -44,16 +44,28 @@ class LegacyToDomainConverter {
 		return $donation;
 	}
 
+	/**
+	 * Create a new status from the payment type.
+	 *
+	 * This method is a violation of the Open-Closed principle because we need to touch it whenever we add new payment types.
+	 * We are planning to remove the status from the Donation domain model all together,
+	 * see https://phabricator.wikimedia.org/T281853
+	 *
+	 * @param DoctrineDonation $dd
+	 *
+	 * @return string
+	 */
 	private function convertStatus( DoctrineDonation $dd ): string {
-		switch ( $dd->getPaymentType() ) {
-			case PaymentMethod::BANK_TRANSFER:
-				return Donation::STATUS_PROMISE;
-			case PaymentMethod::DIRECT_DEBIT:
-				return Donation::STATUS_NEW;
-			default:
-				// TODO ask Kai what to do with old data that would create an error here
-				return $dd->getStatus();
+		$paymentMethod = $this->getPaymentMethodFromEntity( $dd );
+		if ( $paymentMethod instanceof BankTransferPayment ) {
+			return Donation::STATUS_PROMISE;
+		} elseif ( $paymentMethod instanceof DirectDebitPayment ) {
+			return Donation::STATUS_NEW;
+		} elseif ( $paymentMethod->hasExternalProvider() ) {
+			return $paymentMethod->paymentCompleted() ? Donation::STATUS_EXTERNAL_BOOKED : Donation::STATUS_EXTERNAL_INCOMPLETE;
 		}
+		// For greater legacy compatibility (at the cost of future errors), we don't throw an exception here
+		return Donation::STATUS_PROMISE;
 	}
 
 	private function assignCancellationAndModeration( DoctrineDonation $dd, Donation $donation ): void {

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -250,4 +250,41 @@ class ValidDoctrineDonation {
 		return $donation;
 	}
 
+	public static function newIncompleteCreditCardDonation(): Donation {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setPaymentType( PaymentMethod::CREDIT_CARD );
+		$donation->setStatus( Donation::STATUS_EXTERNAL_INCOMPLETE );
+		return $donation;
+	}
+
+	public static function newCreditCardDonation(): Donation {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setPaymentType( PaymentMethod::CREDIT_CARD );
+		$donation->setStatus( Donation::STATUS_EXTERNAL_INCOMPLETE );
+		$donation->encodeAndSetData( array_merge( $donation->getDecodedData(), [
+			'ext_payment_id' => 'spenden.wikimedia.de-IDvooNg2sh#1',
+			'ext_payment_status' => 'processed',
+			'ext_payment_timestamp' => '2020-12-25T15:11:55+01:00',
+			'mcp_amount' => '13.37',
+			'ext_payment_account' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83',
+			'mcp_sessionid' => 'CC42f34220c26b6c33e611b0a2bb89fdaccd295a',
+			'mcp_auth' => 'd8e8fca2dc0f896fd7cb4cb0031ba249',
+			'mcp_title' => 'Ihre Spende an Wikipedia',
+			'mcp_country' => 'DE',
+			'mcp_currency' => 'EUR',
+			'mcp_cc_expiry_date' => '2/2025'
+		] ) );
+		return $donation;
+	}
+
+	public static function newIncompleteSofortDonation(): Donation {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setPaymentType( PaymentMethod::SOFORT );
+		$donation->setStatus( Donation::STATUS_EXTERNAL_INCOMPLETE );
+		return $donation;
+	}
+
 }


### PR DESCRIPTION
Add state conversion for all payments to LegacyToDomainConverter

While working on the conversion, discovered that tracking state is no
longer necessary in the domain and created an issue. See
https://phabricator.wikimedia.org/T281853

This is for https://phabricator.wikimedia.org/T276817
