### PR TITLE
Deprecate state in Donation model

### DIFF
--- a/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
+++ b/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
@@ -66,8 +66,8 @@ class CreditCardNotificationUseCase {
 
 	private function handleRequest( CreditCardPaymentNotificationRequest $request, Donation $donation ): CreditCardNotificationResponse {
 		try {
-			$donation->addCreditCardData( $this->newCreditCardDataFromRequest( $request ) );
 			$donation->confirmBooked();
+			$donation->addCreditCardData( $this->newCreditCardDataFromRequest( $request ) );
 		}
 		catch ( \RuntimeException $e ) {
 			return CreditCardNotificationResponse::newFailureResponse( CreditCardNotificationResponse::DOMAIN_ERROR, $e );

--- a/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCase.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCase.php
@@ -93,10 +93,9 @@ class HandlePayPalPaymentCompletionNotificationUseCase {
 			return $this->createChildDonation( $donation, $request );
 		}
 
-		$paymentMethod->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
-
 		try {
 			$donation->confirmBooked();
+			$paymentMethod->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
 		}
 		catch ( \RuntimeException $ex ) {
 			return $this->createErrorResponse( $ex );

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -69,8 +69,9 @@ class ValidDonation {
 	public const TRACKING_TRACKING = 'test/gelb';
 
 	public const PAYPAL_TRANSACTION_ID = '61E67681CH3238416';
+	public const PAYPAL_PAYER_ID = 'HE373U84ENFYQ';
 
-	public const CREDIT_CARD_TRANSACTION_ID = '';
+	public const CREDIT_CARD_TRANSACTION_ID = '7788998877';
 	public const CREDIT_CARD_EXPIRY_YEAR = 2001;
 	public const CREDIT_CARD_EXPIRY_MONTH = 9;
 
@@ -104,6 +105,7 @@ class ValidDonation {
 	public static function newBookedPayPalDonation( string $transactionId = self::PAYPAL_TRANSACTION_ID ): Donation {
 		$payPalData = new PayPalData();
 		$payPalData->setPaymentId( $transactionId );
+		$payPalData->setPayerId( self::PAYPAL_PAYER_ID );
 
 		return self::createDonation(
 			new PayPalPayment( $payPalData ),

--- a/tests/Unit/Domain/Model/DonationTest.php
+++ b/tests/Unit/Domain/Model/DonationTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Unit\Domain\Model;
 
+use DomainException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
@@ -97,7 +98,7 @@ class DonationTest extends TestCase {
 	public function testGivenNonExternalPaymentType_confirmBookedThrowsException(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
-		$this->expectException( RuntimeException::class );
+		$this->expectException( DomainException::class );
 		$this->expectExceptionMessageMatches( '/Only external payments/' );
 		$donation->confirmBooked();
 	}
@@ -119,7 +120,7 @@ class DonationTest extends TestCase {
 	 * @dataProvider statusesThatDoNotAllowForBookingProvider
 	 */
 	public function testGivenStatusThatDoesNotAllowForBooking_confirmBookedThrowsException( Donation $donation ): void {
-		$this->expectException( RuntimeException::class );
+		$this->expectException( DomainException::class );
 		$donation->confirmBooked();
 	}
 


### PR DESCRIPTION
Delegate isBooked, hasExternalPayment and isIncomplete
to the payment method instead of using the string state. This is a first
step towards https://phabricator.wikimedia.org/T276817

Mark state-related methods and variables as deprecated.

Fix fixtures to comply better with the real-world data.

I had to switch the order of marking the donation as paid and adding
payment information (because marking the donation checks payment
information). This two-part state change looks slightly dangerous to me,
because at least in theory it would be possible to construct a paid
donation without payment information. I have prepared a common interface
for payments in https://github.com/wmde/fundraising-payments/pull/37
When that is merged, the `Donation::confirmBooked` method can get a
payment data parameter and call `$this->payment->bookPayment()`.
