### PR TITLE
Change deprecated method on Sofort payment

### DIFF
--- a/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
+++ b/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
@@ -54,7 +54,7 @@ class SofortPaymentNotificationUseCase {
 			return $this->createUnhandledResponse( 'Wrong access code for donation' );
 		}
 
-		if ( $paymentMethod->isConfirmedPayment() ) {
+		if ( $paymentMethod->paymentCompleted() ) {
 			return $this->createUnhandledResponse( 'Duplicate notification' );
 		}
 


### PR DESCRIPTION
Now that payments have a common interface for checking their completion,
we should use that.
