### PR TITLE
Fix comment update

### DIFF
--- a/src/DataAccess/LegacyCommentRepository.php
+++ b/src/DataAccess/LegacyCommentRepository.php
@@ -18,11 +18,11 @@ use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
  */
 class LegacyCommentRepository implements CommentRepository {
 
-	private array $fetchedComments = [];
+	private array $fetchedDonationsByComment = [];
 	private DonationRepository $donationRepository;
 
 	public function __construct( DonationRepository $donationRepository ) {
- $this->donationRepository = $donationRepository;
+		$this->donationRepository = $donationRepository;
 	}
 
 	public function getCommentById( int $commentId ): ?DonationComment {
@@ -36,7 +36,7 @@ class LegacyCommentRepository implements CommentRepository {
 		}
 		$comment = $donation->getComment();
 		if ( $comment !== null ) {
-			$this->fetchedComments[spl_object_id( $comment )] = $donation->getId();
+			$this->fetchedDonationsByComment[spl_object_id( $comment )] = $donation;
 		}
 		return $comment;
 	}
@@ -54,9 +54,10 @@ class LegacyCommentRepository implements CommentRepository {
 
 	public function updateComment( DonationComment $comment ): void {
 		$objectId = spl_object_id( $comment );
-		if ( !isset( $this->fetchedComments[$objectId] ) ) {
+		if ( !isset( $this->fetchedDonationsByComment[$objectId] ) ) {
 			throw new LegacyException( 'updateComment is not implementable without calling getCommentByDonationId first. Please check your call order and make sure you\'re only updating donations that previously had a comment.' );
 		}
+		$this->donationRepository->storeDonation( $this->fetchedDonationsByComment[$objectId] );
 	}
 
 }

--- a/tests/Integration/DataAccess/LegacyCommentRepositoryTest.php
+++ b/tests/Integration/DataAccess/LegacyCommentRepositoryTest.php
@@ -103,9 +103,9 @@ class LegacyCommentRepositoryTest extends TestCase {
 		$repository->getCommentByDonationId( $donation->getId() );
 		$repository->updateComment( $comment );
 
-		$storeDonationCalls = $donationRepository->getGetDonationCalls();
+		$storeDonationCalls = $donationRepository->getStoreDonationCalls();
 		$this->assertCount( 1, $storeDonationCalls );
-		$this->assertSame( $donation->getId(), $storeDonationCalls[0] );
+		$this->assertEquals( $donation, $storeDonationCalls[0] );
 	}
 
 	public function testUpdateCommentFailsIfLoadedDonationHadNoComment(): void {


### PR DESCRIPTION
A followup for #133 where I used a wrong method on a mock class, leadig to forgetting the actual saving of the donation when a comment should be updated.