### PR TITLE
Use PaymentTransactionData for confirmBooked

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/freezable-value-object": "~2.0",
 		"wmde/fun-validators": "~3.0.0",
-		"wmde/fundraising-payments": "~2.0"
+		"wmde/fundraising-payments": "~2.2"
 	},
 	"repositories": [
 		{

--- a/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
+++ b/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\CreditCardPaymentNotification;
 
+use DomainException;
 use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationRepository;
@@ -66,10 +67,9 @@ class CreditCardNotificationUseCase {
 
 	private function handleRequest( CreditCardPaymentNotificationRequest $request, Donation $donation ): CreditCardNotificationResponse {
 		try {
-			$donation->confirmBooked();
-			$donation->addCreditCardData( $this->newCreditCardDataFromRequest( $request ) );
+			$donation->confirmBooked( $this->newCreditCardDataFromRequest( $request ) );
 		}
-		catch ( \RuntimeException $e ) {
+		catch ( DomainException $e ) {
 			return CreditCardNotificationResponse::newFailureResponse( CreditCardNotificationResponse::DOMAIN_ERROR, $e );
 		}
 

--- a/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCase.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCase.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\HandlePayPalPaymentNotification;
 
+use DomainException;
+use Exception;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\DonationContext\Authorization\DonationAuthorizer;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
@@ -94,10 +96,9 @@ class HandlePayPalPaymentCompletionNotificationUseCase {
 		}
 
 		try {
-			$donation->confirmBooked();
-			$paymentMethod->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
+			$donation->confirmBooked( $this->newPayPalDataFromRequest( $request ) );
 		}
-		catch ( \RuntimeException $ex ) {
+		catch ( DomainException $ex ) {
 			return $this->createErrorResponse( $ex );
 		}
 
@@ -225,7 +226,7 @@ class HandlePayPalPaymentCompletionNotificationUseCase {
 		return $payment->getPayPalData()->hasChildPayment( $transactionId );
 	}
 
-	private function createErrorResponse( \Exception $ex ): PaypalNotificationResponse {
+	private function createErrorResponse( Exception $ex ): PaypalNotificationResponse {
 		return PaypalNotificationResponse::newFailureResponse(
 			[
 				'message' => $ex->getMessage(),

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -103,14 +103,20 @@ class ValidDonation {
 	}
 
 	public static function newBookedPayPalDonation( string $transactionId = self::PAYPAL_TRANSACTION_ID ): Donation {
-		$payPalData = new PayPalData();
+		$payPalData = self::newPayPalData();
 		$payPalData->setPaymentId( $transactionId );
-		$payPalData->setPayerId( self::PAYPAL_PAYER_ID );
 
 		return self::createDonation(
 			new PayPalPayment( $payPalData ),
 			Donation::STATUS_EXTERNAL_BOOKED
 		);
+	}
+
+	public static function newPayPalData(): PayPalData {
+		$payPalData = new PayPalData();
+		$payPalData->setPaymentId( self::PAYPAL_TRANSACTION_ID );
+		$payPalData->setPayerId( self::PAYPAL_PAYER_ID );
+		return $payPalData;
 	}
 
 	public static function newIncompletePayPalDonation(): Donation {
@@ -165,14 +171,17 @@ class ValidDonation {
 	}
 
 	public static function newBookedCreditCardDonation(): Donation {
+		return self::createDonation(
+			new CreditCardPayment( self::newCreditCardData() ),
+			Donation::STATUS_EXTERNAL_BOOKED
+		);
+	}
+
+	public static function newCreditCardData(): CreditCardTransactionData {
 		$creditCardData = new CreditCardTransactionData();
 		$creditCardData->setTransactionId( self::CREDIT_CARD_TRANSACTION_ID );
 		$creditCardData->setCardExpiry( new CreditCardExpiry( self::CREDIT_CARD_EXPIRY_MONTH, self::CREDIT_CARD_EXPIRY_YEAR ) );
-
-		return self::createDonation(
-			new CreditCardPayment( $creditCardData ),
-			Donation::STATUS_EXTERNAL_BOOKED
-		);
+		return $creditCardData;
 	}
 
 	public static function newIncompleteCreditCardDonation(): Donation {

--- a/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -114,7 +114,7 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 		$request = ValidSofortNotificationRequest::newInstantPayment();
 
 		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
-		$this->assertSame( Donation::STATUS_EXTERNAL_BOOKED, $repository->getDonationById( $donation->getId() )->getStatus() );
+		$this->assertTrue( $donation->isBooked() );
 	}
 
 	public function testWhenPaymentTypeIsNonSofort_unhandledResponseIsReturned(): void {


### PR DESCRIPTION
Require PaymentTransactionData when calling Donation::confirmBooked,
making confirmBooked more transactional.

Fix unit tests and add factory methods for payment transaction data in
ValidDonation.

Remove addCreditCardData method from Donation. This is a theoretical BC
break, although no code outside of the bounded context calls the method.

This change is for https://phabricator.wikimedia.org/T276817
