### PR TITLE
Improve donation booking exception message

### DIFF
--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -204,7 +204,10 @@ class Donation {
 		}
 
 		if ( !$this->stateAllowsBooking() ) {
-			throw new DomainException( 'Only valid, unmoderated and incomplete donations can be confirmed as booked' );
+			throw new DomainException( sprintf(
+				'Only valid, unmoderated and incomplete donations can be confirmed as booked. Blocking states: %s',
+				implode( ', ', $this->getStatesThatAllowBooking() ),
+			) );
 		}
 
 		if ( $this->hasComment() && ( $this->isMarkedForModeration() || $this->isCancelled() ) ) {
@@ -227,7 +230,16 @@ class Donation {
 	}
 
 	private function stateAllowsBooking(): bool {
-		return $this->isIncomplete() || $this->isMarkedForModeration() || $this->isCancelled();
+		return count( $this->getStatesThatAllowBooking() ) > 0;
+	}
+
+	private function getStatesThatAllowBooking(): array {
+		$blockingStates = [
+			'incomplete' => $this->isIncomplete(),
+			'moderated' => $this->isMarkedForModeration(),
+			'canceled' => $this->isCancelled()
+			];
+		return array_keys( array_filter( $blockingStates ) );
 	}
 
 	public function markForModeration(): void {


### PR DESCRIPTION
When a donation is blocked from being booked, add the states that
blocked it from being booked to the exception message.

This change is purely for adding information, it does not change how
donations check the state. While investigating this, I saw that the
exception message does not match what the code does.
We'll have to talk to a domain expert to change the message (or the code).
