### PR TITLE
Fix booked status

### DIFF
--- a/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
+++ b/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
@@ -148,7 +148,8 @@ class DomainToLegacyConverter {
 		}
 
 		if ( $paymentMethod instanceof CreditCardPayment ) {
-			return $this->getDataFieldsFromCreditCardData( $paymentMethod->getCreditCardData() );
+			$creditCardTransactionData = $paymentMethod->getCreditCardData();
+			return $creditCardTransactionData === null ? [] : $this->getDataFieldsFromCreditCardData( $creditCardTransactionData );
 		}
 
 		return [];

--- a/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
+++ b/src/DataAccess/LegacyConverters/LegacyToDomainConverter.php
@@ -61,6 +61,8 @@ class LegacyToDomainConverter {
 			return Donation::STATUS_PROMISE;
 		} elseif ( $paymentMethod instanceof DirectDebitPayment ) {
 			return Donation::STATUS_NEW;
+		} elseif ( $paymentMethod instanceof SofortPayment ) {
+			return $paymentMethod->paymentCompleted() ? Donation::STATUS_PROMISE : Donation::STATUS_EXTERNAL_INCOMPLETE;
 		} elseif ( $paymentMethod->hasExternalProvider() ) {
 			return $paymentMethod->paymentCompleted() ? Donation::STATUS_EXTERNAL_BOOKED : Donation::STATUS_EXTERNAL_INCOMPLETE;
 		}

--- a/src/UseCases/AddDonation/PaymentFactory.php
+++ b/src/UseCases/AddDonation/PaymentFactory.php
@@ -1,0 +1,65 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
+
+use WMDE\Fundraising\DonationContext\Domain\Model\DonationPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment;
+use WMDE\Fundraising\PaymentContext\Domain\TransferCodeGenerator;
+
+class PaymentFactory {
+	private const PREFIX_BANK_TRANSACTION_KNOWN_DONOR = 'XW';
+	private const PREFIX_BANK_TRANSACTION_ANONYMOUS_DONOR = 'XR';
+
+	private TransferCodeGenerator $transferCodeGenerator;
+
+	public function __construct( TransferCodeGenerator $transferCodeGenerator ) {
+		$this->transferCodeGenerator = $transferCodeGenerator;
+	}
+
+	public function getPaymentFromRequest( AddDonationRequest $donationRequest ): DonationPayment {
+		return new DonationPayment(
+			$donationRequest->getAmount(),
+			$donationRequest->getInterval(),
+			$this->getPaymentMethodFromRequest( $donationRequest )
+		);
+	}
+
+	private function getPaymentMethodFromRequest( AddDonationRequest $donationRequest ): PaymentMethod {
+		$paymentType = $donationRequest->getPaymentType();
+
+		switch ( $paymentType ) {
+			case PaymentMethod::BANK_TRANSFER:
+				return new BankTransferPayment( $this->getTransferCode( $donationRequest ) );
+			case PaymentMethod::DIRECT_DEBIT:
+				return new DirectDebitPayment( $donationRequest->getBankData() );
+			case PaymentMethod::PAYPAL:
+				return new PayPalPayment( new PayPalData() );
+			case PaymentMethod::CREDIT_CARD:
+				return new CreditCardPayment();
+			case PaymentMethod::SOFORT:
+				return new SofortPayment( $this->getTransferCode( $donationRequest ) );
+			default:
+				throw new \UnexpectedValueException( sprintf( 'Unknown Payment type: %s', $paymentType ) );
+		}
+	}
+
+	private function getTransferCode( AddDonationRequest $request ): string {
+		return $this->transferCodeGenerator->generateTransferCode(
+			$this->getTransferCodePrefix( $request )
+		);
+	}
+
+	private function getTransferCodePrefix( AddDonationRequest $request ): string {
+		if ( $request->donorIsAnonymous() ) {
+			return self::PREFIX_BANK_TRANSACTION_ANONYMOUS_DONOR;
+		}
+		return self::PREFIX_BANK_TRANSACTION_KNOWN_DONOR;
+	}
+}

--- a/tests/Data/InvalidPaymentMethod.php
+++ b/tests/Data/InvalidPaymentMethod.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Data;
+
+use DateTimeImmutable;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
+
+/**
+ * This is a class that should trigger errors in our payment method instance checks
+ */
+class InvalidPaymentMethod implements PaymentMethod {
+	public function getId(): string {
+		return 'CASH';
+	}
+
+	public function hasExternalProvider(): bool {
+		return false;
+	}
+
+	public function paymentCompleted(): bool {
+		return true;
+	}
+
+	public function getValuationDate(): ?DateTimeImmutable {
+		return null;
+	}
+}

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -27,6 +27,7 @@ use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalData;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
 use WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\SofortTransactionData;
 use WMDE\Fundraising\PaymentContext\Infrastructure\CreditCardExpiry;
 
 /**
@@ -135,7 +136,7 @@ class ValidDonation {
 
 	public static function newCompletedSofortDonation(): Donation {
 		$payment = new SofortPayment( self::PAYMENT_BANK_TRANSFER_CODE );
-		$payment->setConfirmedAt( new DateTime( self::SOFORT_DONATION_CONFIRMED_AT ) );
+		$payment->bookPayment( new SofortTransactionData( new \DateTimeImmutable( self::SOFORT_DONATION_CONFIRMED_AT ) ) );
 		return self::createDonation(
 			$payment,
 			Donation::STATUS_PROMISE
@@ -150,22 +151,16 @@ class ValidDonation {
 	}
 
 	public static function newBookedAnonymousPayPalDonation(): Donation {
-		$payPalData = new PayPalData();
-		$payPalData->setPaymentId( self::PAYPAL_TRANSACTION_ID );
-
 		return self::createAnonymousDonation(
-			new PayPalPayment( $payPalData ),
+			new PayPalPayment( self::newPayPalData() ),
 			Donation::STATUS_EXTERNAL_BOOKED
 		);
 	}
 
 	public static function newBookedAnonymousPayPalDonationUpdate( int $donationId ): Donation {
-		$payPalData = new PayPalData();
-		$payPalData->setPaymentId( self::PAYPAL_TRANSACTION_ID );
-
 		return self::createAnonymousDonationWithId(
 			$donationId,
-			new PayPalPayment( $payPalData ),
+			new PayPalPayment( self::newPayPalData() ),
 			Donation::STATUS_EXTERNAL_BOOKED
 		);
 	}

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -181,7 +181,8 @@ class ValidDonation {
 
 	public static function newIncompleteCreditCardDonation(): Donation {
 		return self::createDonation(
-			new CreditCardPayment( new CreditCardTransactionData() ),
+		// We're leaving the transaction data null here on purpose
+			new CreditCardPayment(),
 			Donation::STATUS_EXTERNAL_INCOMPLETE
 		);
 	}

--- a/tests/Fixtures/FixedTransferCodeGenerator.php
+++ b/tests/Fixtures/FixedTransferCodeGenerator.php
@@ -1,0 +1,21 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
+
+use WMDE\Fundraising\PaymentContext\Domain\TransferCodeGenerator;
+
+class FixedTransferCodeGenerator implements TransferCodeGenerator {
+	public const DEFAULT = 'ZZ9 Plural Z Alpha';
+
+	private string $transferCode;
+
+	public function __construct( string $transferCode = self::DEFAULT ) {
+		$this->transferCode = $transferCode;
+	}
+
+	public function generateTransferCode( string $prefix ): string {
+		return $prefix . $this->transferCode;
+	}
+
+}

--- a/tests/Unit/DataAccess/LegacyConverters/DomainToLegacyConverterTest.php
+++ b/tests/Unit/DataAccess/LegacyConverters/DomainToLegacyConverterTest.php
@@ -64,7 +64,7 @@ class DomainToLegacyConverterTest extends TestCase {
 		$this->assertNotSame( 'potato', $data['vorname'], 'Person-related data should change' );
 	}
 
-	public function testTransactionIdsOfChildDondationsAreConverted(): void {
+	public function testTransactionIdsOfChildDonationsAreConverted(): void {
 		$converter = new DomainToLegacyConverter();
 		$transactionId = '16R12136PU8783961';
 		$fakeChildId = 2;
@@ -90,7 +90,7 @@ class DomainToLegacyConverterTest extends TestCase {
 
 	public function testCreditCardWithOutExpiryDateIsConverted(): void {
 		$converter = new DomainToLegacyConverter();
-		$donation = ValidDonation::newIncompleteCreditCardDonation();
+		$donation = ValidDonation::newIncompleteAnonymousCreditCardDonation();
 
 		$doctrineDonation = $converter->convert( $donation, new DoctrineDonation() );
 		$data = $doctrineDonation->getDecodedData();
@@ -168,6 +168,8 @@ class DomainToLegacyConverterTest extends TestCase {
 	}
 
 	public function incompleteDonationProvider(): iterable {
+		// The credit card data tests both null and empty credit card transaction data
+		yield [ ValidDonation::newIncompleteCreditCardDonation() ];
 		yield [ ValidDonation::newIncompleteAnonymousCreditCardDonation() ];
 		yield [ ValidDonation::newIncompleteAnonymousPayPalDonation() ];
 		yield [ ValidDonation::newIncompleteSofortDonation() ];

--- a/tests/Unit/UseCases/AddDonation/PaymentFactoryTest.php
+++ b/tests/Unit/UseCases/AddDonation/PaymentFactoryTest.php
@@ -1,0 +1,158 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Unit\UseCases\AddDonation;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\FixedTransferCodeGenerator;
+use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationRequest;
+use WMDE\Fundraising\DonationContext\UseCases\AddDonation\PaymentFactory;
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
+use WMDE\Fundraising\PaymentContext\Domain\Model\BankTransferPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\CreditCardPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\DirectDebitPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
+use WMDE\Fundraising\PaymentContext\Domain\Model\PayPalPayment;
+use WMDE\Fundraising\PaymentContext\Domain\Model\SofortPayment;
+
+/**
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\AddDonation\PaymentFactory
+ */
+class PaymentFactoryTest extends TestCase {
+	private const AMOUNT = '49.99';
+	public const PAYMENT_BIC = 'INGDDEFFXXX';
+	public const PAYMENT_IBAN = 'DE12500105170648489890';
+
+	public function testDirectDebitRequestCreatesDirectDebitPayment(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator( 'BANK' ) );
+		$bankData = new BankData();
+		$bankData->setIban( new Iban( self::PAYMENT_IBAN ) );
+		$bankData->setBic( self::PAYMENT_BIC );
+		$request = $this->newMinimumDonationRequest( PaymentMethod::DIRECT_DEBIT );
+		$request->setBankData( $bankData );
+
+		$payment = $factory->getPaymentFromRequest( $request );
+		/** @var DirectDebitPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertEquals( Euro::newFromCents( 4999 ), $payment->getAmount() );
+		$this->assertSame( 0, $payment->getIntervalInMonths() );
+		$this->assertInstanceOf( DirectDebitPayment::class, $paymentMethod );
+		$this->assertEquals( $bankData, $paymentMethod->getBankData() );
+	}
+
+	public function testBankTransferRequestCreatesBankTransferPayment(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator( 'BANK' ) );
+
+		$payment = $factory->getPaymentFromRequest( $this->newMinimumDonationRequest( PaymentMethod::BANK_TRANSFER ) );
+		/** @var BankTransferPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertEquals( Euro::newFromCents( 4999 ), $payment->getAmount() );
+		$this->assertSame( 0, $payment->getIntervalInMonths() );
+		$this->assertInstanceOf( BankTransferPayment::class, $paymentMethod );
+		$this->assertSame( 'XRBANK', $paymentMethod->getBankTransferCode() );
+	}
+
+	public function testBankTransferRequestWithNamedDonorCreatesBankTransferPaymentWithDifferentTransferCodePrefix(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator( 'BANK' ) );
+		$request = $this->newMinimumDonationRequest( PaymentMethod::BANK_TRANSFER );
+		$request->setDonorType( DonorType::COMPANY() );
+
+		$payment = $factory->getPaymentFromRequest( $request );
+		/** @var BankTransferPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertInstanceOf( BankTransferPayment::class, $paymentMethod );
+		$this->assertSame( 'XWBANK', $paymentMethod->getBankTransferCode() );
+	}
+
+	public function testCreditCardRequestCreatesCreditCardPayment(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator() );
+
+		$payment = $factory->getPaymentFromRequest( $this->newMinimumDonationRequest( PaymentMethod::CREDIT_CARD ) );
+		/** @var CreditCardPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertEquals( Euro::newFromCents( 4999 ), $payment->getAmount() );
+		$this->assertSame( 0, $payment->getIntervalInMonths() );
+		$this->assertInstanceOf( CreditCardPayment::class, $paymentMethod );
+		$this->assertFalse( $paymentMethod->paymentCompleted(), 'New credit card payments should not be booked' );
+	}
+
+	public function testPayPalRequestCreatesPayPalPayment(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator() );
+
+		$payment = $factory->getPaymentFromRequest( $this->newMinimumDonationRequest( PaymentMethod::PAYPAL ) );
+		/** @var PayPalPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertEquals( Euro::newFromCents( 4999 ), $payment->getAmount() );
+		$this->assertSame( 0, $payment->getIntervalInMonths() );
+		$this->assertInstanceOf( PayPalPayment::class, $paymentMethod );
+		$this->assertFalse( $paymentMethod->paymentCompleted(), 'New PayPal payments should not be booked' );
+	}
+
+	public function testSofortRequestCreatesSofortPayment(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator( 'BANK' ) );
+
+		$payment = $factory->getPaymentFromRequest( $this->newMinimumDonationRequest( PaymentMethod::SOFORT ) );
+		/** @var SofortPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertEquals( Euro::newFromCents( 4999 ), $payment->getAmount() );
+		$this->assertSame( 0, $payment->getIntervalInMonths() );
+		$this->assertInstanceOf( SofortPayment::class, $paymentMethod );
+		$this->assertSame( 'XRBANK', $paymentMethod->getBankTransferCode() );
+		$this->assertFalse( $paymentMethod->paymentCompleted(), 'New Sofort payments should not be booked' );
+	}
+
+	public function testSofortRequestWithNamedDonorCreatesSofortPaymentWithDifferentTransferCodePrefix(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator( 'BANK' ) );
+		$request = $this->newMinimumDonationRequest( PaymentMethod::SOFORT );
+		$request->setDonorType( DonorType::COMPANY() );
+
+		$payment = $factory->getPaymentFromRequest( $request );
+		/** @var SofortPayment $paymentMethod */
+		$paymentMethod = $payment->getPaymentMethod();
+
+		$this->assertInstanceOf( SofortPayment::class, $paymentMethod );
+		$this->assertSame( 'XWBANK', $paymentMethod->getBankTransferCode() );
+	}
+
+	public function testSettingDifferentAmountAndInterval(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator() );
+		$amount = Euro::newFromCents( 100 );
+		$interval = 3;
+		$donationRequest = new AddDonationRequest();
+		$donationRequest->setAmount( $amount );
+		$donationRequest->setInterval( $interval );
+		$donationRequest->setPaymentType( PaymentMethod::PAYPAL );
+		$donationRequest->setDonorType( DonorType::ANONYMOUS() );
+
+		$payment = $factory->getPaymentFromRequest( $donationRequest );
+
+		$this->assertEquals( $amount, $payment->getAmount() );
+		$this->assertSame( $interval, $payment->getIntervalInMonths() );
+	}
+
+	public function testGivenInvalidPaymentType_throwsADomainException(): void {
+		$factory = new PaymentFactory( new FixedTransferCodeGenerator() );
+		$request = $this->newMinimumDonationRequest( "CASH" );
+
+		$this->expectException( \UnexpectedValueException::class );
+
+		$factory->getPaymentFromRequest( $request );
+	}
+
+	private function newMinimumDonationRequest( string $paymentMethod ): AddDonationRequest {
+		$donationRequest = new AddDonationRequest();
+		$donationRequest->setAmount( Euro::newFromString( self::AMOUNT ) );
+		$donationRequest->setPaymentType( $paymentMethod );
+		$donationRequest->setDonorType( DonorType::ANONYMOUS() );
+		return $donationRequest;
+	}
+}


### PR DESCRIPTION
Derive Doctrine donation status from payment:
Pull request #147 (commit 4ebd837 )
removed setting the donation status when a donation payment is booked.
This commit changes the DomainToLegacyConverter to derive the status in
the database from the payment status.

The tests revealed that some test data fixtures were invalid (Payment
data did not appear as booked), which this commit also fixes.

See also https://phabricator.wikimedia.org/T281853

Subsequent refactorings and tests revealed some uncovered code in the payment data handling which this PR also fixes

