### PR TITLE
Add Symfony cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=7.4",
 		"ext-curl": "*",
 
-		"doctrine/orm": "~2.7",
+		"doctrine/orm": "~2.9",
 		"gedmo/doctrine-extensions": "^3.0",
 		"psr/log": "~1.0",
 		"symfony/http-client": "^5.2",
@@ -37,7 +37,7 @@
 	],
 	"require-dev": {
 		"ext-pdo_sqlite": "*",
-
+		"symfony/cache": "^5.3",
 		"phpunit/phpunit": "~9.5.1",
 		"codeception/specify": "~1.0",
 		"phpstan/phpstan": "^0.12",


### PR DESCRIPTION
Doctrine 2.9 has removed internal caching so we need to replace it with the Symfony one