### PR TITLE
Fix Scrutinizer coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,6 @@
 inherit: true
 
 tools:
-    external_code_coverage:
-        timeout: 3600
     php_code_sniffer: true
     php_cpd: false # PHP Copy/Paste Detector and PHP Code Similarity Analyzer cannot both be used simultaneously
     php_cs_fixer: true
@@ -23,10 +21,7 @@ build:
                 override:
                 - php-scrutinizer-run
                 - phpcs-run
-    tests:
-        override:
-        - true # Disable unit tests because they are handled by Travis
-
+    
 build_failure_conditions:
     - 'project.metric_change("scrutinizer.test_coverage", < 0)'
     - 'project.metric_change("scrutinizer.quality", < -0.3)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ script:
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
   - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 1 --no-progress src/ # Can't use "make stan" because stan was removed
 
-after_success:
-  - vendor/bin/phpunit --coverage-clover coverage.clover
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
This change to the Travis and Scrutinizer configuration makes
Scrutinizer generate the coverage information itself.

This change became necessary, because the PHAR version of the coverage
uploader tool "ocular" provided by Scrutinizer is not compatible with
PHP 8. Instead of [installing it globally][1] we drop the external
coverage generation, simplifying the scrutinizer and Travis
configuration at the cost of a slightly longer scrutinizer run.

[1]: scrutinizer-ci/ocular#54 (comment)