### PR TITLE
fix access checker

### DIFF
--- a/src/DataAccess/DoctrineDonationAuthorizer.php
+++ b/src/DataAccess/DoctrineDonationAuthorizer.php
@@ -18,10 +18,10 @@ use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
 class DoctrineDonationAuthorizer implements DonationAuthorizer {
 
 	private EntityManager $entityManager;
-	private ?string $updateToken;
-	private ?string $accessToken;
+	private string $updateToken;
+	private string $accessToken;
 
-	public function __construct( EntityManager $entityManager, string $updateToken = null, string $accessToken = null ) {
+	public function __construct( EntityManager $entityManager, string $updateToken = '', string $accessToken = '' ) {
 		$this->entityManager = $entityManager;
 		$this->updateToken = $updateToken;
 		$this->accessToken = $accessToken;
@@ -53,7 +53,7 @@ class DoctrineDonationAuthorizer implements DonationAuthorizer {
 	private function updateTokenMatches( Donation $donation ): bool {
 		return hash_equals(
 			(string)$donation->getDataObject()->getUpdateToken(),
-			(string)$this->updateToken
+			$this->updateToken
 		);
 	}
 
@@ -87,7 +87,7 @@ class DoctrineDonationAuthorizer implements DonationAuthorizer {
 	private function accessTokenMatches( Donation $donation ): bool {
 		return hash_equals(
 			(string)$donation->getDataObject()->getAccessToken(),
-			(string)$this->accessToken
+			$this->accessToken
 		);
 	}
 

--- a/src/DataAccess/DoctrineDonationAuthorizer.php
+++ b/src/DataAccess/DoctrineDonationAuthorizer.php
@@ -13,7 +13,6 @@ use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
 
 /**
  * @license GPL-2.0-or-later
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DoctrineDonationAuthorizer implements DonationAuthorizer {
 
@@ -51,6 +50,9 @@ class DoctrineDonationAuthorizer implements DonationAuthorizer {
 	}
 
 	private function updateTokenMatches( Donation $donation ): bool {
+		if ( $this->updateToken === '' ) {
+			return false;
+		}
 		return hash_equals(
 			(string)$donation->getDataObject()->getUpdateToken(),
 			$this->updateToken
@@ -85,6 +87,9 @@ class DoctrineDonationAuthorizer implements DonationAuthorizer {
 	}
 
 	private function accessTokenMatches( Donation $donation ): bool {
+		if ( $this->accessToken === '' ) {
+			return false;
+		}
 		return hash_equals(
 			(string)$donation->getDataObject()->getAccessToken(),
 			$this->accessToken

--- a/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
@@ -18,7 +18,6 @@ use WMDE\Fundraising\DonationContext\Tests\TestEnvironment;
  * @covers \WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationAuthorizer
  *
  * @license GPL-2.0-or-later
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DoctrineDonationAuthorizerTest extends TestCase {
 	use Specify;
@@ -28,6 +27,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 	private const WRONG__UPDATE_TOKEN = 'WrongUpdateToken';
 	private const WRONG_ACCESS_TOKEN = 'WrongAccessToken';
 	private const MEANINGLESS_TOKEN = 'Some token';
+	private const EMPTY_TOKEN = '';
 	private const MEANINGLESS_DONATION_ID = 1337;
 	private const ID_OF_WRONG_DONATION = 42;
 
@@ -143,9 +143,25 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 	public function testGivenTokenAndLegacyDonation_accessAuthorizationFails(): void {
 		$donation = new Donation();
 		$this->storeDonation( $donation );
-		$authorizer = $this->newAuthorizationService( '', self::MEANINGLESS_TOKEN );
+		$authorizer = $this->newAuthorizationService( self::EMPTY_TOKEN, self::MEANINGLESS_TOKEN );
+
+		$this->assertFalse( $authorizer->canAccessDonation( $donation->getId() ) );
+	}
+
+	public function testGivenEmptyTokenAndLegacyDonation_updateAuthorizationFails(): void {
+		$donation = new Donation();
+		$this->storeDonation( $donation );
+		$authorizer = $this->newAuthorizationService( self::EMPTY_TOKEN, self::EMPTY_TOKEN );
 
 		$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
+	}
+
+	public function testGivenEmptyTokenAndLegacyDonation_accessAuthorizationFails(): void {
+		$donation = new Donation();
+		$this->storeDonation( $donation );
+		$authorizer = $this->newAuthorizationService( self::EMPTY_TOKEN, self::EMPTY_TOKEN );
+
+		$this->assertFalse( $authorizer->canAccessDonation( $donation->getId() ) );
 	}
 
 	/**

--- a/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
@@ -15,7 +15,7 @@ use WMDE\Fundraising\DonationContext\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\DonationContext\Tests\TestEnvironment;
 
 /**
- * @covers WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationAuthorizer
+ * @covers \WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationAuthorizer
  *
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -37,7 +37,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 	}
 
-	private function newAuthorizationService( string $updateToken = null, string $accessToken = null ): DonationAuthorizer {
+	private function newAuthorizationService( string $updateToken = '', string $accessToken = '' ): DonationAuthorizer {
 		return new DoctrineDonationAuthorizer( $this->entityManager, $updateToken, $accessToken );
 	}
 
@@ -98,7 +98,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$this->specify(
 			'given correct donation id and wrong token, update authorization fails',
 			function () use ( $donation ): void {
-				$authorizer = $this->newAuthorizationService( self::WRONG__UPDATE_TOKEN, null );
+				$authorizer = $this->newAuthorizationService( self::WRONG__UPDATE_TOKEN );
 				$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
 			}
 		);
@@ -106,7 +106,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$this->specify(
 			'given correct donation id and correct token, access authorization succeeds',
 			function () use ( $donation ): void {
-				$authorizer = $this->newAuthorizationService( null, self::CORRECT_ACCESS_TOKEN );
+				$authorizer = $this->newAuthorizationService( '', self::CORRECT_ACCESS_TOKEN );
 				$this->assertTrue( $authorizer->canAccessDonation( $donation->getId() ) );
 			}
 		);
@@ -114,7 +114,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$this->specify(
 			'given wrong donation id and correct token, access authorization fails',
 			function (): void {
-				$authorizer = $this->newAuthorizationService( null, self::CORRECT_ACCESS_TOKEN );
+				$authorizer = $this->newAuthorizationService( '', self::CORRECT_ACCESS_TOKEN );
 				$this->assertFalse( $authorizer->canAccessDonation( self::ID_OF_WRONG_DONATION ) );
 			}
 		);
@@ -122,7 +122,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$this->specify(
 			'given correct donation id and wrong token, access authorization fails',
 			function () use ( $donation ): void {
-				$authorizer = $this->newAuthorizationService( null, self::WRONG_ACCESS_TOKEN );
+				$authorizer = $this->newAuthorizationService( '', self::WRONG_ACCESS_TOKEN );
 				$this->assertFalse( $authorizer->canAccessDonation( $donation->getId() ) );
 			}
 		);
@@ -150,7 +150,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$this->specify(
 			'given correct donation id and a token, access authorization fails',
 			function () use ( $donation ): void {
-				$authorizer = $this->newAuthorizationService( null, self::MEANINGLESS_TOKEN );
+				$authorizer = $this->newAuthorizationService( '', self::MEANINGLESS_TOKEN );
 				$this->assertFalse( $authorizer->canAccessDonation( $donation->getId() ) );
 			}
 		);
@@ -242,7 +242,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$donation->setDataObject( $donationData );
 		$this->storeDonation( $donation );
 
-		$donAuthorizer = new DoctrineDonationAuthorizer( $this->entityManager );
+		$donAuthorizer = new DoctrineDonationAuthorizer( $this->entityManager, '', '' );
 		$resultTokenSet = $donAuthorizer->getTokensForDonation( $donation->getId() );
 
 		$this->assertSame( self::CORRECT_ACCESS_TOKEN, $resultTokenSet->getAccessToken() );
@@ -257,7 +257,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$mockEM = $this->createMock( EntityManager::class );
 		$mockEM->method( 'find' )->willReturn( $donation );
 
-		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM );
+		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM, '', '' );
 
 		$this->expectException( \UnexpectedValueException::class );
 		$donAuthorizer->getTokensForDonation( self::MEANINGLESS_DONATION_ID );
@@ -271,7 +271,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$mockEM = $this->createMock( EntityManager::class );
 		$mockEM->method( 'find' )->willReturn( $donation );
 
-		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM );
+		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM, '', '' );
 
 		$this->expectException( \UnexpectedValueException::class );
 		$donAuthorizer->getTokensForDonation( self::MEANINGLESS_DONATION_ID );
@@ -281,7 +281,7 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		$mockEM = $this->createMock( EntityManager::class );
 		$mockEM->method( 'find' )->willReturn( null );
 
-		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM );
+		$donAuthorizer = new DoctrineDonationAuthorizer( $mockEM, '', '' );
 
 		$this->expectException( GetDonationException::class );
 		$donAuthorizer->getTokensForDonation( self::MEANINGLESS_DONATION_ID );

--- a/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
@@ -132,28 +132,20 @@ class DoctrineDonationAuthorizerTest extends TestCase {
 		return date( 'Y-m-d H:i:s', time() + 60 * 60 );
 	}
 
-	/**
-	 * @slowThreshold 400
-	 */
-	public function testWhenDonationWithoutTokenExists(): void {
+	public function testGivenTokenAndLegacyDonation_updateAuthorizationFails(): void {
 		$donation = new Donation();
 		$this->storeDonation( $donation );
+		$authorizer = $this->newAuthorizationService( self::MEANINGLESS_TOKEN );
 
-		$this->specify(
-			'given correct donation id and a token, update authorization fails',
-			function () use ( $donation ): void {
-				$authorizer = $this->newAuthorizationService( self::MEANINGLESS_TOKEN );
-				$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
-			}
-		);
+		$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
+	}
 
-		$this->specify(
-			'given correct donation id and a token, access authorization fails',
-			function () use ( $donation ): void {
-				$authorizer = $this->newAuthorizationService( '', self::MEANINGLESS_TOKEN );
-				$this->assertFalse( $authorizer->canAccessDonation( $donation->getId() ) );
-			}
-		);
+	public function testGivenTokenAndLegacyDonation_accessAuthorizationFails(): void {
+		$donation = new Donation();
+		$this->storeDonation( $donation );
+		$authorizer = $this->newAuthorizationService( '', self::MEANINGLESS_TOKEN );
+
+		$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
 	}
 
 	/**


### PR DESCRIPTION
- Make token parameters non-nullable
- Refactor DoctrineDonationAuthorizerTest
- Fail authorization with empty tokens

This fixes https://phabricator.wikimedia.org/T288525 for donations.