### PR TITLE
Update dependencies for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 
 		"doctrine/orm": "~2.9",
 		"gedmo/doctrine-extensions": "^3.0",
-		"psr/log": "~1.0",
+		"psr/log": "^1.0|^2.0|^3.0",
 		"symfony/http-client": "^5.2",
 
 		"wmde/email-address": "~1.0",
@@ -40,12 +40,12 @@
 		"symfony/cache": "^5.3",
 		"phpunit/phpunit": "~9.5.1",
 		"codeception/specify": "~2.0",
-		"phpstan/phpstan": "^1.0",
+		"phpstan/phpstan": "^1.7",
 		"phpmd/phpmd": "~2.6",
 
 		"mikey179/vfsstream": "~1.6",
 		"wmde/fundraising-phpcs": "~7.0.0",
-		"wmde/psr-log-test-doubles": "~2.1"
+		"wmde/psr-log-test-doubles": "^2.1|^3.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Adapt logger dependencies to use more modern psr/log version if
possible/needed.