### PR TITLE
Simplify NotificationResponse

### DIFF
--- a/src/UseCases/BookDonationUseCase/BookDonationUseCase.php
+++ b/src/UseCases/BookDonationUseCase/BookDonationUseCase.php
@@ -47,12 +47,12 @@ class BookDonationUseCase {
 		$isFollowupPayment = false;
 
 		if ( !$this->authorizationService->systemCanModifyDonation( $donationId ) ) {
-			return NotificationResponse::newUnhandledResponse( 'Wrong access code for donation' );
+			return NotificationResponse::newFailureResponse( 'Wrong access code for donation' );
 		}
 
 		$result = $this->paymentBookingService->bookPayment( $donation->getPaymentId(), $request->bookingData );
 		if ( $result instanceof FailureResponse ) {
-			return NotificationResponse::newUnhandledResponse( $result->message );
+			return NotificationResponse::newFailureResponse( $result->message );
 		}
 		if ( $result instanceof FollowUpSuccessResponse ) {
 			$donation = $donation->createFollowupDonationForPayment( $result->childPaymentId );

--- a/src/UseCases/NotificationResponse.php
+++ b/src/UseCases/NotificationResponse.php
@@ -5,41 +5,26 @@ namespace WMDE\Fundraising\DonationContext\UseCases;
 
 class NotificationResponse {
 
-	private bool $wasHandled;
-	private bool $notificationFailed;
-	private string $message;
-
-	private function __construct( bool $notificationWasHandled, bool $isError, string $message = '' ) {
-		$this->wasHandled = $notificationWasHandled;
-		$this->notificationFailed = $isError;
-		$this->message = $message;
+	private function __construct( private readonly string $message = '' ) {
 	}
 
 	public static function newSuccessResponse(): self {
-		return new self( true, false );
-	}
-
-	/**
-	 * @todo Check if this method is really required when booking Use Cases are refactored
-	 *
-	 * @param string $message
-	 *
-	 * @return self
-	 */
-	public static function newUnhandledResponse( string $message ): self {
-		return new self( false, false, $message );
+		return new self( '' );
 	}
 
 	public static function newFailureResponse( string $message ): self {
-		return new self( false, true, $message );
+		if ( $message === '' ) {
+			throw new \DomainException( 'Failure response must not be empty' );
+		}
+		return new self( $message );
 	}
 
 	public function notificationWasHandled(): bool {
-		return $this->wasHandled;
+		return $this->message === '';
 	}
 
 	public function hasErrors(): bool {
-		return $this->notificationFailed;
+		return $this->message !== '';
 	}
 
 	public function getMesssage(): string {

--- a/tests/Unit/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/tests/Unit/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -24,6 +24,7 @@ use WMDE\Fundraising\PaymentContext\UseCases\BookPayment\SuccessResponse;
 
 /**
  * @covers \WMDE\Fundraising\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardNotificationUseCase
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\NotificationResponse
  *
  */
 class CreditCardNotificationUseCaseTest extends TestCase {
@@ -42,7 +43,7 @@ class CreditCardNotificationUseCaseTest extends TestCase {
 
 		$response = $useCase->handleNotification( $request );
 
-		$this->assertFalse( $response->notificationWasHandled() );
+		$this->assertTrue( $response->hasErrors() );
 		$this->assertSame( 'Wrong access code for donation', $response->getMesssage() );
 	}
 
@@ -134,7 +135,7 @@ class CreditCardNotificationUseCaseTest extends TestCase {
 
 		$response = $useCase->handleNotification( $request );
 
-		$this->assertFalse( $response->notificationWasHandled() );
+		$this->assertTrue( $response->hasErrors() );
 		$this->assertSame( 'Amount does not match', $response->getMesssage() );
 	}
 

--- a/tests/Unit/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
+++ b/tests/Unit/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
@@ -26,12 +26,13 @@ use WMDE\Fundraising\PaymentContext\UseCases\BookPayment\SuccessResponse;
 
 /**
  * @covers \WMDE\Fundraising\DonationContext\UseCases\HandlePayPalPaymentNotification\HandlePayPalPaymentCompletionNotificationUseCase
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\NotificationResponse
  */
 class HandlePayPalPaymentCompletionNotificationUseCaseTest extends TestCase {
 
 	use DonationEventLoggerAsserter;
 
-	public function testWhenAuthorizationFails_unhandledResponseIsReturned(): void {
+	public function testWhenAuthorizationFails_failureResponseIsReturned(): void {
 		$request = ValidPayPalNotificationRequest::newInstantPayment( 1 );
 		$useCase = $this->givenNewUseCase(
 			authorizer: new FailingDonationAuthorizer()

--- a/tests/Unit/UseCases/HandlePaypalPaymentWithoutDonation/HandlePaypalPaymentWithoutDonationUseCaseTest.php
+++ b/tests/Unit/UseCases/HandlePaypalPaymentWithoutDonation/HandlePaypalPaymentWithoutDonationUseCaseTest.php
@@ -16,6 +16,7 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreateBookedPayPalPayment\SuccessRe
 
 /**
  * @covers \WMDE\Fundraising\DonationContext\UseCases\HandlePaypalPaymentWithoutDonation\HandlePaypalPaymentWithoutDonationUseCase
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\NotificationResponse
  */
 class HandlePaypalPaymentWithoutDonationUseCaseTest extends TestCase {
 

--- a/tests/Unit/UseCases/NotificationResponseTest.php
+++ b/tests/Unit/UseCases/NotificationResponseTest.php
@@ -1,0 +1,38 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Unit\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\DonationContext\UseCases\NotificationResponse;
+
+/**
+ * @covers \WMDE\Fundraising\DonationContext\UseCases\NotificationResponse
+ */
+class NotificationResponseTest extends TestCase {
+	public function testSuccessResponseHasNoErrors(): void {
+		$response = NotificationResponse::newSuccessResponse();
+
+		$this->assertTrue( $response->notificationWasHandled() );
+		$this->assertFalse( $response->hasErrors() );
+		$this->assertSame( '', $response->getMesssage() );
+	}
+
+	public function testFailureResponseHasErrorMessage(): void {
+		$response = NotificationResponse::newFailureResponse( 'These are not the payments you\'re looking for' );
+
+		$this->assertFalse( $response->notificationWasHandled() );
+		$this->assertTrue( $response->hasErrors() );
+		$this->assertSame(
+			'These are not the payments you\'re looking for',
+			$response->getMesssage()
+		);
+	}
+
+	public function testFailureResponseMessageMustNotBeEmpty(): void {
+		$this->expectException( \DomainException::class );
+
+		NotificationResponse::newFailureResponse( '' );
+	}
+
+}


### PR DESCRIPTION
Don't distinguish between "Failure" and "Unhandled". A Failure response
is something that we have to investigate internally where we don't want
the payment provider to retry. Everything else is probably an exception,
where we do want the payment provider to retry.

This is for https://phabricator.wikimedia.org/T309092