### PR TITLE
Check for allowed payment types

### DIFF
--- a/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -184,7 +184,7 @@ class AddDonationUseCase {
 			$paymentRequest->bic,
 			$paymentReferenceCodePrefix
 		);
-		$request->setDomainSpecificPaymentValidator( new DonationPaymentValidator() );
+		$request->setDomainSpecificPaymentValidator( $this->paymentService->createPaymentValidator() );
 		return $request;
 	}
 

--- a/src/UseCases/AddDonation/CreatePaymentService.php
+++ b/src/UseCases/AddDonation/CreatePaymentService.php
@@ -9,4 +9,6 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as Pa
 
 interface CreatePaymentService {
 	public function createPayment( PaymentCreationRequest $request ): PaymentCreationFailed|PaymentCreationSucceeded;
+
+	public function createPaymentValidator(): DonationPaymentValidator;
 }

--- a/src/UseCases/AddDonation/CreatePaymentWithUseCase.php
+++ b/src/UseCases/AddDonation/CreatePaymentWithUseCase.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse as PaymentCreationFailed;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
@@ -10,11 +11,22 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as Pa
 
 class CreatePaymentWithUseCase implements CreatePaymentService {
 
-	public function __construct( private CreatePaymentUseCase $createPaymentUseCase ) {
+	/**
+	 * @param CreatePaymentUseCase $createPaymentUseCase
+	 * @param PaymentType[] $allowedPaymentTypes
+	 */
+	public function __construct(
+		private CreatePaymentUseCase $createPaymentUseCase,
+		private array $allowedPaymentTypes
+ ) {
 	}
 
 	public function createPayment( PaymentCreationRequest $request ): PaymentCreationFailed|PaymentCreationSucceeded {
 		return $this->createPaymentUseCase->createPayment( $request );
+	}
+
+	public function createPaymentValidator(): DonationPaymentValidator {
+		return new DonationPaymentValidator( $this->allowedPaymentTypes );
 	}
 
 }

--- a/tests/Fixtures/CreatePaymentServiceSpy.php
+++ b/tests/Fixtures/CreatePaymentServiceSpy.php
@@ -3,7 +3,8 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
-use PHPUnit\Framework\Assert;
+use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as PaymentCreationSucceeded;
 
@@ -18,16 +19,12 @@ class CreatePaymentServiceSpy extends SucceedingPaymentServiceStub {
 		return parent::createPayment( $request );
 	}
 
-	public function getRequests(): array {
-		return $this->requests;
+	public function createPaymentValidator(): DonationPaymentValidator {
+		return new DonationPaymentValidator( PaymentType::cases() );
 	}
 
 	public function getLastRequest(): PaymentCreationRequest {
 		return $this->requests[0];
-	}
-
-	public function assertCalledOnce(): void {
-		Assert::assertCount( 1, $this->requests );
 	}
 
 }

--- a/tests/Fixtures/SucceedingPaymentServiceStub.php
+++ b/tests/Fixtures/SucceedingPaymentServiceStub.php
@@ -5,6 +5,8 @@ namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidPayments;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\CreatePaymentService;
+use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentUrlGenerator\NullGenerator;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as PaymentCreationSucceeded;
@@ -23,6 +25,10 @@ class SucceedingPaymentServiceStub implements CreatePaymentService {
 
 	public function createPayment( PaymentCreationRequest $request ): PaymentCreationSucceeded {
 		return $this->successResponse;
+	}
+
+	public function createPaymentValidator(): DonationPaymentValidator {
+		return new DonationPaymentValidator( PaymentType::cases() );
 	}
 
 }

--- a/tests/Unit/UseCases/AddDonation/DonationPaymentValidatorTest.php
+++ b/tests/Unit/UseCases/AddDonation/DonationPaymentValidatorTest.php
@@ -14,11 +14,16 @@ use WMDE\FunValidators\ConstraintViolation;
  * @covers \WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator
  */
 class DonationPaymentValidatorTest extends TestCase {
+
+	private const ALLOWED_PAYMENT_TYPES = [
+		PaymentType::CreditCard
+	];
+
 	/**
 	 * @dataProvider getValidAmounts
 	 */
 	public function testGivenValidAmount_validatorReturnsNoViolations( float $amount ): void {
-		$validator = new DonationPaymentValidator();
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromFloat( $amount ), PaymentInterval::OneTime, PaymentType::CreditCard );
 
@@ -32,7 +37,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenSmallAmount_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator();
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromCents( 99 ), PaymentInterval::OneTime, PaymentType::CreditCard );
 
@@ -44,7 +49,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenLargeAmount_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator();
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 100_000 ), PaymentInterval::OneTime, PaymentType::CreditCard );
 
@@ -54,4 +59,17 @@ class DonationPaymentValidatorTest extends TestCase {
 			$validationResult->getValidationErrors()[0]
 		);
 	}
+
+	public function testGivenDisallowedPaymentType_validatorReturnsViolation(): void {
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
+
+		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 99 ), PaymentInterval::OneTime, PaymentType::Paypal );
+
+		$this->assertFalse( $validationResult->isSuccessful() );
+		$this->assertEquals(
+			new ConstraintViolation( PaymentType::Paypal->value, DonationPaymentValidator::FORBIDDEN_PAYMENT_TYPE, DonationPaymentValidator::SOURCE_PAYMENT_TYPE ),
+			$validationResult->getValidationErrors()[0]
+		);
+	}
+
 }


### PR DESCRIPTION
DonationPaymentValidator, the domain-specific validator now checks for
allowed payment types. This introduces additional security for the
backend, where we previously relied on the client-side code to present
only allowed payments.

The AddDonationUseCase can now no longer initialize the class directly
(since it's not supposed to know about the payment configuration), so I
pushed the initialization to CreatePaymentService, where it will be
initialized by the FunFunFactory.

This is also a good preparation for https://phabricator.wikimedia.org/T312087