### PR TITLE
Modernize database initialization

### DIFF
--- a/src/DonationContextFactory.php
+++ b/src/DonationContextFactory.php
@@ -21,23 +21,38 @@ use WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationPrePersistSubscr
 class DonationContextFactory {
 
 	/**
-	 * Use this constant for MappingDriverChain::addDriver
+	 * Used MappingDriverChain::addDriver
+	 * @deprecated use {@see getDoctrineMappingPaths}
 	 */
 	public const ENTITY_NAMESPACE = 'WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities';
 
 	private const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';
 
 	protected array $config;
-	protected Configuration $doctrineConfiguration;
+
+	/**
+	 * @var Configuration|null
+	 * @deprecated Will be removed in next major release
+	 */
+	protected ?Configuration $doctrineConfiguration;
 	private AnnotationReader $annotationReader;
 
 	protected ?TokenGenerator $tokenGenerator;
 
-	public function __construct( array $config, Configuration $doctrineConfiguration ) {
+	public function __construct( array $config, ?Configuration $doctrineConfiguration = null ) {
 		$this->config = $config;
 		$this->doctrineConfiguration = $doctrineConfiguration;
 		$this->tokenGenerator = null;
 		$this->annotationReader = new AnnotationReader();
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getDoctrineMappingPaths(): array {
+		return [
+			self::DOCTRINE_CLASS_MAPPING_DIRECTORY
+		];
 	}
 
 	/**
@@ -52,6 +67,10 @@ class DonationContextFactory {
 		);
 	}
 
+	/**
+	 * @return MappingDriver
+	 * @deprecated Use ORMSetup::createXMLMetadataConfiguration with {@see getDoctrineMappingPaths instead}
+	 */
 	public function newMappingDriver(): MappingDriver {
 		return new XmlDriver( self::DOCTRINE_CLASS_MAPPING_DIRECTORY );
 	}

--- a/tests/TestDonationContextFactory.php
+++ b/tests/TestDonationContextFactory.php
@@ -5,20 +5,17 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\DonationContext\Tests;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\ORMSetup;
 use Gedmo\Timestampable\TimestampableListener;
 use WMDE\Fundraising\DonationContext\DonationContextFactory;
 use WMDE\Fundraising\DonationContext\Tests\Fixtures\FixedTokenGenerator;
 
 class TestDonationContextFactory {
 
-	private Configuration $doctrineConfig;
 	private DonationContextFactory $contextFactory;
 	private array $config;
 
@@ -27,10 +24,8 @@ class TestDonationContextFactory {
 
 	public function __construct( array $config ) {
 		$this->config = $config;
-		$this->doctrineConfig = Setup::createConfiguration( true );
 		$this->contextFactory = new DonationContextFactory(
 			$config,
-			$this->doctrineConfig
 		);
 		$this->contextFactory->setTokenGenerator( new FixedTokenGenerator() );
 		$this->entityManager = null;
@@ -52,10 +47,9 @@ class TestDonationContextFactory {
 	}
 
 	private function newEntityManager( array $eventSubscribers = [] ): EntityManager {
-		AnnotationRegistry::registerLoader( 'class_exists' );
-		$this->doctrineConfig->setMetadataDriverImpl( $this->contextFactory->newMappingDriver() );
+		$doctrineConfig = ORMSetup::createXMLMetadataConfiguration( DonationContextFactory::getDoctrineMappingPaths() );
 
-		$entityManager = EntityManager::create( $this->getConnection(), $this->doctrineConfig );
+		$entityManager = EntityManager::create( $this->getConnection(), $doctrineConfig );
 
 		$this->setupEventSubscribers( $entityManager->getEventManager(), $eventSubscribers );
 


### PR DESCRIPTION
We won't be using a MappingDriverChain, but rely on ORMSetup.
See TestDonationContextFactory on how the Fundraising App and FOC will
later initialize the EntityManager.

This is not a BC break, we just deprecate things.

This is for https://phabricator.wikimedia.org/T312080