### PR TITLE
Add response for donation not found

### DIFF
--- a/src/UseCases/BookDonationUseCase/BookDonationUseCase.php
+++ b/src/UseCases/BookDonationUseCase/BookDonationUseCase.php
@@ -36,7 +36,7 @@ class BookDonationUseCase {
 		$donation = $this->repository->getDonationById( $request->donationId );
 
 		if ( $donation === null ) {
-			return NotificationResponse::newFailureResponse( 'Donation not found' );
+			return NotificationResponse::newDonationNotFoundResponse();
 		}
 
 		return $this->handleRequestForDonation( $request, $donation );

--- a/src/UseCases/NotificationResponse.php
+++ b/src/UseCases/NotificationResponse.php
@@ -5,6 +5,8 @@ namespace WMDE\Fundraising\DonationContext\UseCases;
 
 class NotificationResponse {
 
+	private const DONATION_NOT_FOUND_MESSAGE = 'Donation not found';
+
 	private function __construct( private readonly string $message = '' ) {
 	}
 
@@ -19,6 +21,10 @@ class NotificationResponse {
 		return new self( $message );
 	}
 
+	public static function newDonationNotFoundResponse(): self {
+		return new self( self::DONATION_NOT_FOUND_MESSAGE );
+	}
+
 	public function notificationWasHandled(): bool {
 		return $this->message === '';
 	}
@@ -29,5 +35,9 @@ class NotificationResponse {
 
 	public function getMessage(): string {
 		return $this->message;
+	}
+
+	public function donationWasNotFound(): bool {
+		return $this->message === self::DONATION_NOT_FOUND_MESSAGE;
 	}
 }

--- a/tests/Unit/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
+++ b/tests/Unit/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
@@ -215,6 +215,20 @@ class HandlePayPalPaymentCompletionNotificationUseCaseTest extends TestCase {
 		$this->assertSame( $errorMessage, $response->getMessage(), 'Response should contain message from payment service' );
 	}
 
+	public function testDonationDoesNotExist_returnsDonationWasNotFoundResponse(): void {
+		$repository = $this->createMock( DonationRepository::class );
+		$repository->method( 'getDonationById' )->willReturn( null );
+
+		$request = ValidPayPalNotificationRequest::newInstantPayment( 1 );
+
+		$useCase = $this->givenNewUseCase( repository: $repository );
+
+		$response = $useCase->handleNotification( $request );
+
+		$this->assertFalse( $response->notificationWasHandled() );
+		$this->assertTrue( $response->donationWasNotFound() );
+	}
+
 	/**
 	 * Create a new use case with stubs that would make it pass
 	 *


### PR DESCRIPTION
We need a way to distinguish when a donation is
missing against other failures. This is because
we often get anonymous payments for PayPal that
need to be handled separately rather than just
booked.

Ticket: https://phabricator.wikimedia.org/T307892