### PR TITLE
Fix payment_id migration

### DIFF
--- a/src/DataAccess/Migrations/Version20220516152124.php
+++ b/src/DataAccess/Migrations/Version20220516152124.php
@@ -21,9 +21,14 @@ final class Version20220516152124 extends AbstractMigration {
 	}
 
 	public function up( Schema $schema ): void {
+		// Drop the foreign key references to be able to rename the `payment_id` column
+		$this->addSql( 'ALTER TABLE spenden DROP FOREIGN KEY FK_3CBBD0454C3A3BB' );
+		$this->addSql( 'DROP INDEX UNIQ_3CBBD0454C3A3BB ON spenden' );
+
 		// Rename the old bounded-context-specific payment_id to legacy
 		// We still need it for the data migration
 		$this->addSql( 'ALTER TABLE spenden CHANGE COLUMN payment_id legacy_payment_id INTEGER' );
+
 		// Add the new payment_id. Strictly speaking, this is a non-nullable foreign key, but we can't model it as such
 		// We'll add the unique index in the next migration to keep the data migration fast
 		$this->addSql( 'ALTER TABLE spenden ADD COLUMN payment_id INTEGER DEFAULT 0' );


### PR DESCRIPTION
Running the migration in test failed because our live database has a
foreign key constraint that the dev environment doesn't have. We ran the
new statements in the MySQL clients, but amend the migration class for
the migration of the production environment.