### PR TITLE
Ignore opt-ins for anonymous donations

### DIFF
--- a/src/DataAccess/DoctrineEntities/Donation.php
+++ b/src/DataAccess/DoctrineEntities/Donation.php
@@ -186,7 +186,9 @@ class Donation {
 	/**
 	 * Get donation receipt state
 	 *
-	 * @return bool
+	 * This field was introduced without proper migration, so it can be null
+	 *
+	 * @return bool|null
 	 */
 	public function getDonationReceipt(): ?bool {
 		return $this->donationReceipt;

--- a/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
+++ b/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
@@ -26,10 +26,11 @@ class DomainToLegacyConverter {
 		$doctrineDonation->setId( $donation->getId() );
 		$this->updatePaymentInformation( $doctrineDonation, $legacyPaymentData );
 		$doctrineDonation->setPaymentId( $donation->getPaymentId() );
-		DonorFieldMapper::updateDonorInformation( $doctrineDonation, $donation->getDonor() );
+		$donor = $donation->getDonor();
+		DonorFieldMapper::updateDonorInformation( $doctrineDonation, $donor );
 		$this->updateComment( $doctrineDonation, $donation->getComment() );
-		$doctrineDonation->setDonorOptsIntoNewsletter( $donation->getOptsIntoNewsletter() );
-		$doctrineDonation->setDonationReceipt( $donation->getOptsIntoDonationReceipt() );
+		$doctrineDonation->setDonorOptsIntoNewsletter( $donor->wantsNewsletter() );
+		$doctrineDonation->setDonationReceipt( $donor->wantsReceipt() );
 		$this->updateStatusInformation( $doctrineDonation, $donation, $legacyPaymentData );
 
 		// TODO create $this->updateExportState($doctrineDonation, $donation);

--- a/src/Domain/Model/Donor.php
+++ b/src/Domain/Model/Donor.php
@@ -30,4 +30,16 @@ interface Donor {
 	 * @return string
 	 */
 	public function getDonorType(): string;
+
+	public function subscribeToNewsletter(): void;
+
+	public function unsubscribeFromNewsletter(): void;
+
+	public function wantsNewsletter(): bool;
+
+	public function requireReceipt(): void;
+
+	public function declineReceipt(): void;
+
+	public function wantsReceipt(): bool;
 }

--- a/src/Domain/Model/Donor/AnonymousDonor.php
+++ b/src/Domain/Model/Donor/AnonymousDonor.php
@@ -28,4 +28,28 @@ class AnonymousDonor extends AbstractDonor {
 		return (string)DonorType::ANONYMOUS();
 	}
 
+	public function subscribeToNewsletter(): void {
+		// Do nothing, this donor doesn't support newsletters
+	}
+
+	public function unsubscribeFromNewsletter(): void {
+		// Do nothing, this donor doesn't support newsletters
+	}
+
+	public function wantsNewsletter(): bool {
+		return false;
+	}
+
+	public function requireReceipt(): void {
+		// Do nothing, this donor doesn't support receipts
+	}
+
+	public function declineReceipt(): void {
+		// Do nothing, this donor doesn't support receipts
+	}
+
+	public function wantsReceipt(): bool {
+		return false;
+	}
+
 }

--- a/src/Domain/Model/Donor/CompanyDonor.php
+++ b/src/Domain/Model/Donor/CompanyDonor.php
@@ -9,11 +9,17 @@ use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\CompanyName;
 use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 
 class CompanyDonor extends AbstractDonor {
+	use NewsletterTrait;
+	use ReceiptTrait;
 
 	public function __construct( CompanyName $name, PostalAddress $address, string $emailAddress ) {
 		$this->name = $name;
 		$this->physicalAddress = $address;
 		$this->emailAddress = $emailAddress;
+
+		// Server defaults for newsletter and receipt
+		$this->unsubscribeFromNewsletter();
+		$this->requireReceipt();
 	}
 
 	public function isPrivatePerson(): bool {

--- a/src/Domain/Model/Donor/EmailDonor.php
+++ b/src/Domain/Model/Donor/EmailDonor.php
@@ -9,11 +9,14 @@ use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\PersonName;
 use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 
 class EmailDonor extends AbstractDonor {
+	use NewsletterTrait;
 
 	public function __construct( PersonName $name, string $emailAddress ) {
 		$this->name = $name;
 		$this->emailAddress = $emailAddress;
 		$this->physicalAddress = new NoAddress();
+		// Server defaults for newsletter
+		$this->unsubscribeFromNewsletter();
 	}
 
 	public function isPrivatePerson(): bool {
@@ -28,4 +31,15 @@ class EmailDonor extends AbstractDonor {
 		return (string)DonorType::EMAIL();
 	}
 
+	public function requireReceipt(): void {
+		// Do nothing, this donor doesn't support receipts
+	}
+
+	public function declineReceipt(): void {
+		// Do nothing, this donor doesn't support receipts
+	}
+
+	public function wantsReceipt(): bool {
+		return false;
+	}
 }

--- a/src/Domain/Model/Donor/NewsletterTrait.php
+++ b/src/Domain/Model/Donor/NewsletterTrait.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\Domain\Model\Donor;
+
+trait NewsletterTrait {
+	private bool $newsletter;
+
+	public function subscribeToNewsletter(): void {
+		$this->newsletter = true;
+	}
+
+	public function unsubscribeFromNewsletter(): void {
+		$this->newsletter = false;
+	}
+
+	public function wantsNewsletter(): bool {
+		return $this->newsletter;
+	}
+}

--- a/src/Domain/Model/Donor/PersonDonor.php
+++ b/src/Domain/Model/Donor/PersonDonor.php
@@ -9,11 +9,17 @@ use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\PersonName;
 use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 
 class PersonDonor extends AbstractDonor {
+	use NewsletterTrait;
+	use ReceiptTrait;
 
 	public function __construct( PersonName $name, PostalAddress $address, string $emailAddress ) {
 		$this->name = $name;
 		$this->physicalAddress = $address;
 		$this->emailAddress = $emailAddress;
+
+		// Server defaults for newsletter and receipt
+		$this->unsubscribeFromNewsletter();
+		$this->requireReceipt();
 	}
 
 	public function isPrivatePerson(): bool {

--- a/src/Domain/Model/Donor/ReceiptTrait.php
+++ b/src/Domain/Model/Donor/ReceiptTrait.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\Domain\Model\Donor;
+
+trait ReceiptTrait {
+	private bool $receipt;
+
+	public function requireReceipt(): void {
+		$this->receipt = true;
+	}
+
+	public function declineReceipt(): void {
+		$this->receipt = false;
+	}
+
+	public function wantsReceipt(): bool {
+		return $this->receipt;
+	}
+}

--- a/src/Infrastructure/DonationMailer.php
+++ b/src/Infrastructure/DonationMailer.php
@@ -48,7 +48,7 @@ class DonationMailer implements DonationNotifier {
 				'needsModeration' => $donation->isMarkedForModeration(),
 				'moderationFlags' => $this->getModerationFlags( ...$donation->getModerationReasons() ),
 				'bankTransferCode' => $paymentInfo['paymentReferenceCode'] ?? '',
-				'receiptOptIn' => $donation->getOptsIntoDonationReceipt(),
+				'receiptOptIn' => $donation->getDonor()->wantsReceipt(),
 			]
 		];
 	}

--- a/src/UseCases/AddDonation/AddDonationRequest.php
+++ b/src/UseCases/AddDonation/AddDonationRequest.php
@@ -265,6 +265,10 @@ class AddDonationRequest {
 		return $this->getDonorType()->is( DonorType::ANONYMOUS() );
 	}
 
+	public function donorIsEmailOnly(): bool {
+		return $this->getDonorType()->is( DonorType::EMAIL() );
+	}
+
 	public function setOptsIntoDonationReceipt( bool $optIn ): void {
 		$this->optsIntoDonationReceipt = $optIn;
 	}

--- a/src/UseCases/AddDonation/AddDonationRequest.php
+++ b/src/UseCases/AddDonation/AddDonationRequest.php
@@ -25,12 +25,7 @@ class AddDonationRequest {
 	private string $donorCountryCode = '';
 	private string $donorEmailAddress = '';
 
-	/**
-	 * Newsletter subscription
-	 *
-	 * @var string
-	 */
-	private string $optIn = '';
+	private bool $optsInToNewsletter = false;
 
 	private PaymentRequestBuilder $paymentCreationRequestBuilder;
 
@@ -69,12 +64,13 @@ class AddDonationRequest {
 		$this->paymentCreationRequestBuilder = new PaymentRequestBuilder();
 	}
 
-	public function getOptIn(): string {
-		return $this->optIn;
-	}
-
+	/**
+	 * @param string $optIn
+	 * @return void
+	 * @deprecated Use {@see setOptsIntoNewsletter}. Remove this when Controllers in Fundraising App no longer use it
+	 */
 	public function setOptIn( string $optIn ): void {
-		$this->optIn = trim( $optIn );
+		$this->setOptsIntoNewsletter( trim( $optIn ) === '1' );
 	}
 
 	/**
@@ -275,6 +271,14 @@ class AddDonationRequest {
 
 	public function getOptsIntoDonationReceipt(): bool {
 		return $this->optsIntoDonationReceipt;
+	}
+
+	public function getOptsIntoNewsletter(): bool {
+		return $this->optsInToNewsletter;
+	}
+
+	public function setOptsIntoNewsletter( bool $optIn ): void {
+		$this->optsInToNewsletter = $optIn;
 	}
 
 	public function getPaymentCreationRequest(): PaymentCreationRequest {

--- a/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -99,16 +99,14 @@ class AddDonationUseCase {
 	}
 
 	private function newDonationFromRequest( AddDonationRequest $donationRequest, int $paymentId ): Donation {
-		$donation = new Donation(
+		$donor = $this->getPersonalInfoFromRequest( $donationRequest );
+		$this->processNewsletterAndReceiptOptions( $donationRequest, $donor );
+		return new Donation(
 			null,
-			$this->getPersonalInfoFromRequest( $donationRequest ),
+			$donor,
 			$paymentId,
-			$donationRequest->getOptsIntoNewsletter(),
 			$this->newTrackingInfoFromRequest( $donationRequest )
 		);
-		$donation->setOptsIntoDonationReceipt( $donationRequest->getOptsIntoDonationReceipt() );
-
-		return $donation;
 	}
 
 	private function getPersonalInfoFromRequest( AddDonationRequest $request ): Donor {
@@ -212,6 +210,20 @@ class AddDonationUseCase {
 	 */
 	private function generatePayPalInvoiceId( Donation $donation ): string {
 		return 'D' . $donation->getId();
+	}
+
+	private function processNewsletterAndReceiptOptions( AddDonationRequest $donationRequest, Donor $donor ): void {
+		if ( $donationRequest->getOptsIntoDonationReceipt() ) {
+			$donor->requireReceipt();
+		} else {
+			$donor->declineReceipt();
+		}
+
+		if ( $donationRequest->getOptsIntoNewsletter() ) {
+			$donor->subscribeToNewsletter();
+		} else {
+			$donor->unsubscribeFromNewsletter();
+		}
 	}
 
 }

--- a/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -103,7 +103,7 @@ class AddDonationUseCase {
 			null,
 			$this->getPersonalInfoFromRequest( $donationRequest ),
 			$paymentId,
-			$donationRequest->getOptIn() === '1',
+			$donationRequest->getOptsIntoNewsletter(),
 			$this->newTrackingInfoFromRequest( $donationRequest )
 		);
 		$donation->setOptsIntoDonationReceipt( $donationRequest->getOptsIntoDonationReceipt() );

--- a/src/UseCases/HandlePaypalPaymentWithoutDonation/HandlePaypalPaymentWithoutDonationUseCase.php
+++ b/src/UseCases/HandlePaypalPaymentWithoutDonation/HandlePaypalPaymentWithoutDonationUseCase.php
@@ -41,11 +41,8 @@ class HandlePaypalPaymentWithoutDonationUseCase {
 			null,
 			new AnonymousDonor(),
 			$result->paymentId,
-			Donation::DOES_NOT_OPT_INTO_NEWSLETTER,
 			DonationTrackingInfo::newBlankTrackingInfo(),
 		);
-
-		$donation->setOptsIntoDonationReceipt( false );
 
 		$this->donationRepository->storeDonation( $donation );
 

--- a/tests/Data/ValidAddDonationRequest.php
+++ b/tests/Data/ValidAddDonationRequest.php
@@ -14,7 +14,7 @@ class ValidAddDonationRequest {
 	public static function getRequest(): AddDonationRequest {
 		$request = new AddDonationRequest();
 		$request->setPaymentCreationRequest( self::newPaymentCreationRequest() );
-		$request->setOptIn( (string)ValidDonation::OPTS_INTO_NEWSLETTER );
+		$request->setOptsIntoNewsletter( ValidDonation::OPTS_INTO_NEWSLETTER );
 		$request->setDonorType( DonorType::PERSON() );
 		$request->setDonorSalutation( ValidDonation::DONOR_SALUTATION );
 		$request->setDonorTitle( ValidDonation::DONOR_TITLE );

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -142,6 +142,7 @@ class ValidDoctrineDonation {
 		$donation->setDonorEmail( ValidDonation::DONOR_EMAIL_ADDRESS );
 		$donation->setDonorFullName( ValidDonation::DONOR_FULL_NAME );
 		$donation->setDonorOptsIntoNewsletter( ValidDonation::OPTS_INTO_NEWSLETTER );
+		$donation->setDonationReceipt( true );
 
 		$donation->encodeAndSetData(
 			array_merge(

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -36,7 +36,7 @@ class ValidDonation {
 	public const DONATION_AMOUNT = 13.37;
 	public const PAYMENT_INTERVAL_IN_MONTHS = 3;
 
-	public const OPTS_INTO_NEWSLETTER = Donation::OPTS_INTO_NEWSLETTER;
+	public const OPTS_INTO_NEWSLETTER = true;
 	public const TRACKING_BANNER_IMPRESSION_COUNT = 1;
 	public const TRACKING_TOTAL_IMPRESSION_COUNT = 3;
 	// "tracking" is the name of the property on the object, "TRACKING" is our prefix, hence TRACKING_TRACKING
@@ -148,21 +148,23 @@ class ValidDonation {
 	}
 
 	private static function createDonation( Payment $payment ): Donation {
+		$donor = self::newDonor();
+		$donor->subscribeToNewsletter();
 		return new Donation(
 			null,
-			self::newDonor(),
+			$donor,
 			$payment->getId(),
-			self::OPTS_INTO_NEWSLETTER,
 			self::newTrackingInfo()
 		);
 	}
 
 	private static function createCancelledDonation( Payment $payment ): Donation {
+		$donor = self::newDonor();
+		$donor->subscribeToNewsletter();
 		$donation = new Donation(
 			null,
-			self::newDonor(),
+			$donor,
 			$payment->getId(),
-			self::OPTS_INTO_NEWSLETTER,
 			self::newTrackingInfo()
 		);
 		$donation->cancelWithoutChecks();
@@ -174,7 +176,6 @@ class ValidDonation {
 			null,
 			new AnonymousDonor(),
 			$payment->getId(),
-			false,
 			self::newTrackingInfo()
 		);
 	}
@@ -184,7 +185,6 @@ class ValidDonation {
 			$donationId,
 			new AnonymousDonor(),
 			$payment->getId(),
-			false,
 			self::newTrackingInfo()
 		);
 	}

--- a/tests/Fixtures/FakeDonor.php
+++ b/tests/Fixtures/FakeDonor.php
@@ -1,0 +1,29 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
+
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AbstractDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\NewsletterTrait;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\ReceiptTrait;
+
+/**
+ * This class is for testing "this should never happen" code in the DonorFieldMapper donor type checking.
+ */
+class FakeDonor extends AbstractDonor {
+	use NewsletterTrait;
+	use ReceiptTrait;
+
+	public function isPrivatePerson(): bool {
+		return false;
+	}
+
+	public function isCompany(): bool {
+		return false;
+	}
+
+	public function getDonorType(): string {
+		return 'Just testing';
+	}
+
+}

--- a/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
+++ b/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
@@ -303,7 +303,7 @@ class AddDonationUseCaseTest extends TestCase {
 		$this->assertTrue( $repository->getDonationById( 1 )->isCancelled() );
 	}
 
-	public function testOptingIntoDonationReceipt_persistedInDonation(): void {
+	public function testOptingIntoDonationReceipt_persistedInDonor(): void {
 		$repository = $this->makeDonationRepositoryStub();
 		$useCase = $this->makeUseCase( repository: $repository );
 
@@ -312,10 +312,10 @@ class AddDonationUseCaseTest extends TestCase {
 
 		$useCase->addDonation( $request );
 
-		$this->assertTrue( $repository->getDonationById( 1 )->getOptsIntoDonationReceipt() );
+		$this->assertTrue( $repository->getDonationById( 1 )->getDonor()->wantsReceipt() );
 	}
 
-	public function testOptingOutOfDonationReceipt_persistedInDonation(): void {
+	public function testOptingOutOfDonationReceipt_persistedInDonor(): void {
 		$repository = $this->makeDonationRepositoryStub();
 		$useCase = $this->makeUseCase( repository: $repository );
 
@@ -324,7 +324,31 @@ class AddDonationUseCaseTest extends TestCase {
 
 		$useCase->addDonation( $request );
 
-		$this->assertFalse( $repository->getDonationById( 1 )->getOptsIntoDonationReceipt() );
+		$this->assertFalse( $repository->getDonationById( 1 )->getDonor()->wantsReceipt() );
+	}
+
+	public function testOptingIntoNewsletter_persistedInDonor(): void {
+		$repository = $this->makeDonationRepositoryStub();
+		$useCase = $this->makeUseCase( repository: $repository );
+
+		$request = $this->newValidAddDonationRequestWithEmail( 'foo@bar.baz' );
+		$request->setOptsIntoNewsletter( true );
+
+		$useCase->addDonation( $request );
+
+		$this->assertTrue( $repository->getDonationById( 1 )->getDonor()->wantsNewsletter() );
+	}
+
+	public function testOptingOutOfNewsletter_persistedInDonor(): void {
+		$repository = $this->makeDonationRepositoryStub();
+		$useCase = $this->makeUseCase( repository: $repository );
+
+		$request = $this->newValidAddDonationRequestWithEmail( 'foo@bar.baz' );
+		$request->setOptsIntoNewsletter( false );
+
+		$useCase->addDonation( $request );
+
+		$this->assertFalse( $repository->getDonationById( 1 )->getDonor()->wantsNewsletter() );
 	}
 
 	private function makeUseCase(

--- a/tests/Unit/DataAccess/DonorFieldMapperTest.php
+++ b/tests/Unit/DataAccess/DonorFieldMapperTest.php
@@ -7,6 +7,7 @@ use WMDE\Fundraising\DonationContext\DataAccess\DonorFieldMapper;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDoctrineDonation;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\FakeDonor;
 
 /**
  * This test is only testing the safeguards against developer error,
@@ -20,20 +21,7 @@ class DonorFieldMapperTest extends TestCase {
 		$this->expectException( \UnexpectedValueException::class );
 		$this->expectExceptionMessageMatches( '/Could not determine address type/' );
 
-		$testDonor = new class extends Donor\AbstractDonor {
-
-			public function isPrivatePerson(): bool {
-				return false;
-			}
-
-			public function isCompany(): bool {
-				return false;
-			}
-
-			public function getDonorType(): string {
-				return 'Just testing';
-			}
-		};
+		$testDonor = new FakeDonor();
 
 		DonorFieldMapper::getPersonalDataFields( $testDonor );
 	}

--- a/tests/Unit/Domain/Model/DonationTest.php
+++ b/tests/Unit/Domain/Model/DonationTest.php
@@ -69,7 +69,6 @@ class DonationTest extends TestCase {
 			null,
 			ValidDonation::newDonor(),
 			ValidPayments::newDirectDebitPayment()->getId(),
-			Donation::OPTS_INTO_NEWSLETTER,
 			ValidDonation::newTrackingInfo(),
 			null
 		);
@@ -87,7 +86,6 @@ class DonationTest extends TestCase {
 			null,
 			ValidDonation::newDonor(),
 			ValidPayments::newDirectDebitPayment()->getId(),
-			Donation::OPTS_INTO_NEWSLETTER,
 			ValidDonation::newTrackingInfo(),
 			ValidDonation::newPublicComment()
 		);
@@ -101,7 +99,6 @@ class DonationTest extends TestCase {
 			null,
 			ValidDonation::newDonor(),
 			ValidPayments::newDirectDebitPayment()->getId(),
-			Donation::OPTS_INTO_NEWSLETTER,
 			ValidDonation::newTrackingInfo(),
 			null
 		);
@@ -151,7 +148,6 @@ class DonationTest extends TestCase {
 		$this->assertSame( 99, $followupUpDonation->getPaymentId() );
 		$this->assertEquals( $followupUpDonation->getDonor(), $donation->getDonor() );
 		$this->assertEquals( $followupUpDonation->getTrackingInfo(), $donation->getTrackingInfo() );
-		$this->assertEquals( $followupUpDonation->getOptsIntoNewsletter(), $donation->getOptsIntoNewsletter() );
 		$this->assertFalse( $followupUpDonation->isExported() );
 	}
 

--- a/tests/Unit/Infrastructure/DonationConfirmationMailerTest.php
+++ b/tests/Unit/Infrastructure/DonationConfirmationMailerTest.php
@@ -46,7 +46,7 @@ class DonationConfirmationMailerTest extends TestCase {
 				'needsModeration' => false,
 				'paymentType' => 'UEB',
 				'bankTransferCode' => ValidPayments::PAYMENT_BANK_TRANSFER_CODE,
-				'receiptOptIn' => null,
+				'receiptOptIn' => true,
 				'moderationFlags' => [],
 			]
 		] );

--- a/tests/Unit/UseCases/AddDonation/AddDonationRequestTest.php
+++ b/tests/Unit/UseCases/AddDonation/AddDonationRequestTest.php
@@ -133,4 +133,30 @@ class AddDonationRequestTest extends TestCase {
 		$this->assertTrue( $request->getOptsIntoNewsletter() );
 	}
 
+	public function testDonorIsAnonymous(): void {
+		$anonRequest = new AddDonationRequest();
+		$anonRequest->setDonorType( DonorType::ANONYMOUS() );
+		$personRequest = new AddDonationRequest();
+		$personRequest->setDonorType( DonorType::PERSON() );
+		$emailOnlyRequest = new AddDonationRequest();
+		$emailOnlyRequest->setDonorType( DonorType::EMAIL() );
+
+		$this->assertTrue( $anonRequest->donorIsAnonymous() );
+		$this->assertFalse( $personRequest->donorIsAnonymous() );
+		$this->assertFalse( $emailOnlyRequest->donorIsAnonymous() );
+	}
+
+	public function testDonorIsEmailOnly(): void {
+		$anonRequest = new AddDonationRequest();
+		$anonRequest->setDonorType( DonorType::ANONYMOUS() );
+		$personRequest = new AddDonationRequest();
+		$personRequest->setDonorType( DonorType::PERSON() );
+		$emailOnlyRequest = new AddDonationRequest();
+		$emailOnlyRequest->setDonorType( DonorType::EMAIL() );
+
+		$this->assertFalse( $anonRequest->donorIsEmailOnly() );
+		$this->assertFalse( $personRequest->donorIsEmailOnly() );
+		$this->asserttrue( $emailOnlyRequest->donorIsEmailOnly() );
+	}
+
 }

--- a/tests/Unit/UseCases/AddDonation/AddDonationRequestTest.php
+++ b/tests/Unit/UseCases/AddDonation/AddDonationRequestTest.php
@@ -96,10 +96,10 @@ class AddDonationRequestTest extends TestCase {
 
 	public function testOptIn(): void {
 		$request = new AddDonationRequest();
-		$request->setOptIn( 'newsletter_optin' );
+		$request->setOptsIntoNewsletter( true );
 		$request->setOptsIntoDonationReceipt( true );
 
-		$this->assertSame( 'newsletter_optin', $request->getOptIn() );
+		$this->assertTrue( $request->getOptsIntoNewsletter() );
 		$this->assertTrue( $request->getOptsIntoDonationReceipt() );
 	}
 
@@ -130,7 +130,7 @@ class AddDonationRequestTest extends TestCase {
 		$this->assertSame( 'ZZ', $request->getDonorCountryCode() );
 		$this->assertSame( 'bw@waynecorp.biz', $request->getDonorEmailAddress() );
 		$this->assertSame( 'test_campaign/test_keyword', $request->getTracking() );
-		$this->assertSame( '1', $request->getOptIn() );
+		$this->assertTrue( $request->getOptsIntoNewsletter() );
 	}
 
 }

--- a/tests/Unit/UseCases/HandlePaypalPaymentWithoutDonation/HandlePaypalPaymentWithoutDonationUseCaseTest.php
+++ b/tests/Unit/UseCases/HandlePaypalPaymentWithoutDonation/HandlePaypalPaymentWithoutDonationUseCaseTest.php
@@ -44,7 +44,6 @@ class HandlePaypalPaymentWithoutDonationUseCaseTest extends TestCase {
 
 		$this->assertSame( 1, $donation->getPaymentId() );
 		$this->assertTrue( $donation->donorIsAnonymous() );
-		$this->assertFalse( $donation->getOptsIntoDonationReceipt() );
 		$this->assertFalse( $result->hasErrors() );
 		$this->assertCount( 1, $logs );
 		$this->assertStringContainsString( 'booked', $logs[0][1] );


### PR DESCRIPTION
Move the choice for receiving a receipt and receiving the newsletter
into the `Donor` domain class. This way each donor type can implement
its own rules for setting/getting those values.

Current donor rules are:

- Private and company donors will handle receipt and newsletter parameters
  as before.
- Anonymous donors don't support newsletters and receipt and will silently
  ignore the user-selected options (which might come from a broken
  frontend form or API call).
- Email-Only donors don't support donation receipts (those are mailed out
  via postal mail) and will silently ignore the user-selected option.

Adapt the converters and other classes to call the accessors on donor
instead of donation.

Remove donation getters from tests.

Change default values in the valid fixtures.

This change only affects the domain model. `AddDonationRequest` and the
Doctrine `Donation` entity still use the "optIn" terms. We might change
that in subsequent commits.

This change should be considered backwards-compatible:

- The constructor of the `Donation` class changed, but it should not be
  called by outside code. It still might break some test code in the
  Fundraising Application, but that should be rectified in the tests,
  not via a new major release.
- The `AddDonationRequest` has backwards-compatible accessors.

Ticket: https://phabricator.wikimedia.org/T323279
