### PR TITLE
Add paymentWasAlreadyCompleted to NotificationResponse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/freezable-value-object": "~2.0",
 		"wmde/fun-validators": "~4.0",
-		"wmde/fundraising-payments": "~5.0"
+		"wmde/fundraising-payments": "~5.3"
 	},
 	"repositories": [
 		{

--- a/src/UseCases/BookDonationUseCase/BookDonationUseCase.php
+++ b/src/UseCases/BookDonationUseCase/BookDonationUseCase.php
@@ -53,7 +53,7 @@ class BookDonationUseCase {
 
 		$result = $this->paymentBookingService->bookPayment( $donation->getPaymentId(), $request->bookingData );
 		if ( $result instanceof FailureResponse ) {
-			return NotificationResponse::newFailureResponse( $result->message );
+			return $this->createFailureResponseFromPaymentServiceResponse( $result );
 		}
 		if ( $result instanceof FollowUpSuccessResponse ) {
 			$donation = $donation->createFollowupDonationForPayment( $result->childPaymentId );
@@ -85,6 +85,13 @@ class BookDonationUseCase {
 			$followUpId,
 			"book_donation_use_case: new transaction id to corresponding parent donation: $parentId"
 		);
+	}
+
+	private function createFailureResponseFromPaymentServiceResponse( FailureResponse $result ): NotificationResponse {
+		if ( $result->paymentWasAlreadyCompleted() ) {
+			return NotificationResponse::newAlreadyCompletedResponse();
+		}
+		return NotificationResponse::newFailureResponse( $result->message );
 	}
 
 }

--- a/src/UseCases/NotificationResponse.php
+++ b/src/UseCases/NotificationResponse.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\DonationContext\UseCases;
 class NotificationResponse {
 
 	private const DONATION_NOT_FOUND_MESSAGE = 'Donation not found';
+	private const ALREADY_COMPLETED_MESSAGE = 'Payment was booked before';
 
 	private function __construct( private readonly string $message = '' ) {
 	}
@@ -25,6 +26,10 @@ class NotificationResponse {
 		return new self( self::DONATION_NOT_FOUND_MESSAGE );
 	}
 
+	public static function newAlreadyCompletedResponse(): self {
+		return new self( self::ALREADY_COMPLETED_MESSAGE );
+	}
+
 	public function notificationWasHandled(): bool {
 		return $this->message === '';
 	}
@@ -39,5 +44,9 @@ class NotificationResponse {
 
 	public function donationWasNotFound(): bool {
 		return $this->message === self::DONATION_NOT_FOUND_MESSAGE;
+	}
+
+	public function paymentWasAlreadyCompleted(): bool {
+		return $this->message === self::ALREADY_COMPLETED_MESSAGE;
 	}
 }


### PR DESCRIPTION
Add a new static constructor and a boolean getter to NotificationResponse that indicates if the failed NotificationResponse was  caused by an already booked payment. This will help upstream code to check against this condition without using hard-coded string messages (that might change).

Ticket: https://phabricator.wikimedia.org/T321346