### PR TITLE
Prevent anonymous direct debit donations

### DIFF
--- a/src/UseCases/AddDonation/CreatePaymentService.php
+++ b/src/UseCases/AddDonation/CreatePaymentService.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse as PaymentCreationFailed;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as PaymentCreationSucceeded;
@@ -10,5 +11,5 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as Pa
 interface CreatePaymentService {
 	public function createPayment( PaymentCreationRequest $request ): PaymentCreationFailed|PaymentCreationSucceeded;
 
-	public function createPaymentValidator(): DonationPaymentValidator;
+	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator;
 }

--- a/src/UseCases/AddDonation/CreatePaymentWithUseCase.php
+++ b/src/UseCases/AddDonation/CreatePaymentWithUseCase.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse as PaymentCreationFailed;
@@ -25,8 +26,8 @@ class CreatePaymentWithUseCase implements CreatePaymentService {
 		return $this->createPaymentUseCase->createPayment( $request );
 	}
 
-	public function createPaymentValidator(): DonationPaymentValidator {
-		return new DonationPaymentValidator( $this->allowedPaymentTypes );
+	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator {
+		return new DonationPaymentValidator( $this->allowedPaymentTypes, $donorType );
 	}
 
 }

--- a/src/UseCases/AddDonation/DonationPaymentValidator.php
+++ b/src/UseCases/AddDonation/DonationPaymentValidator.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
 use WMDE\Euro\Euro;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
@@ -55,6 +56,11 @@ class DonationPaymentValidator implements DomainSpecificPaymentValidator {
 	public const FORBIDDEN_PAYMENT_TYPE = 'forbidden_payment_type';
 
 	/**
+	 * Violation identifier for {@see ConstraintViolation}
+	 */
+	public const FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE = 'forbidden_payment_type_for_donor_type';
+
+	/**
 	 * Error source name for {@see ConstraintViolation}
 	 */
 	public const SOURCE_AMOUNT = 'amount';
@@ -67,7 +73,10 @@ class DonationPaymentValidator implements DomainSpecificPaymentValidator {
 	private Euro $minimumAmount;
 	private Euro $maximumAmount;
 
-	public function __construct( private array $allowedPaymentTypes ) {
+	public function __construct(
+		private readonly array $allowedPaymentTypes,
+		private readonly DonorType $donorType
+	) {
 		$this->minimumAmount = Euro::newFromInt( self::MINIMUM_AMOUNT_IN_EUROS );
 		$this->maximumAmount = Euro::newFromInt( self::MAXIMUM_AMOUNT_IN_EUROS );
 	}
@@ -100,6 +109,12 @@ class DonationPaymentValidator implements DomainSpecificPaymentValidator {
 		if ( $amountInCents >= $this->maximumAmount->getEuroCents() ) {
 			return ValidationResponse::newFailureResponse( [
 				new ConstraintViolation( $amountInCents, self::AMOUNT_TOO_HIGH, self::SOURCE_AMOUNT )
+			] );
+		}
+
+		if ( $this->donorType->is( DonorType::ANONYMOUS() ) && $paymentType === PaymentType::DirectDebit ) {
+			return ValidationResponse::newFailureResponse( [
+				new ConstraintViolation( $paymentType->value, self::FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE, self::SOURCE_PAYMENT_TYPE )
 			] );
 		}
 

--- a/tests/Fixtures/CreatePaymentServiceSpy.php
+++ b/tests/Fixtures/CreatePaymentServiceSpy.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
@@ -19,8 +20,8 @@ class CreatePaymentServiceSpy extends SucceedingPaymentServiceStub {
 		return parent::createPayment( $request );
 	}
 
-	public function createPaymentValidator(): DonationPaymentValidator {
-		return new DonationPaymentValidator( PaymentType::cases() );
+	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator {
+		return new DonationPaymentValidator( PaymentType::cases(), $donorType );
 	}
 
 	public function getLastRequest(): PaymentCreationRequest {

--- a/tests/Fixtures/SucceedingPaymentServiceStub.php
+++ b/tests/Fixtures/SucceedingPaymentServiceStub.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidPayments;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\CreatePaymentService;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
@@ -27,8 +28,8 @@ class SucceedingPaymentServiceStub implements CreatePaymentService {
 		return $this->successResponse;
 	}
 
-	public function createPaymentValidator(): DonationPaymentValidator {
-		return new DonationPaymentValidator( PaymentType::cases() );
+	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator {
+		return new DonationPaymentValidator( PaymentType::cases(), $donorType );
 	}
 
 }

--- a/tests/Unit/UseCases/AddDonation/DonationPaymentValidatorTest.php
+++ b/tests/Unit/UseCases/AddDonation/DonationPaymentValidatorTest.php
@@ -5,6 +5,7 @@ namespace WMDE\Fundraising\DonationContext\Tests\Unit\UseCases\AddDonation;
 
 use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
@@ -23,7 +24,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	 * @dataProvider getValidAmounts
 	 */
 	public function testGivenValidAmount_validatorReturnsNoViolations( float $amount ): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::PERSON() );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromFloat( $amount ), PaymentInterval::OneTime, PaymentType::DirectDebit );
 
@@ -37,7 +38,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenSmallAmount_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::PERSON() );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromCents( 99 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
 
@@ -49,7 +50,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenLargeAmount_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::PERSON() );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 100_000 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
 
@@ -61,7 +62,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenDisallowedPaymentType_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::COMPANY() );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 99 ), PaymentInterval::OneTime, PaymentType::Paypal );
 
@@ -72,4 +73,15 @@ class DonationPaymentValidatorTest extends TestCase {
 		);
 	}
 
+	public function testGivenAnonymousDonorAndDirectDebitPayment_validatorReturnsViolation(): void {
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::ANONYMOUS() );
+
+		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 99 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
+
+		$this->assertFalse( $validationResult->isSuccessful() );
+		$this->assertEquals(
+			new ConstraintViolation( PaymentType::DirectDebit->value, DonationPaymentValidator::FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE, DonationPaymentValidator::SOURCE_PAYMENT_TYPE ),
+			$validationResult->getValidationErrors()[0]
+		);
+	}
 }


### PR DESCRIPTION
We need at least a name and email address for direct debit donations, so
our domain should prevent those donations.

Discovered while working on Ticket https://phabricator.wikimedia.org/T324082
which deals with an A/B test of the Address type selection in the
frontend.
