### PR TITLE
Direct debit validation

### DIFF
--- a/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -194,9 +194,7 @@ class AddDonationUseCase {
 			$paymentRequest->bic,
 			$paymentReferenceCodePrefix
 		);
-		$newPaymentCreationRequest->setDomainSpecificPaymentValidator(
-			$this->paymentService->createPaymentValidator( $request->getDonorType() )
-		);
+		$newPaymentCreationRequest->setDomainSpecificPaymentValidator( $this->paymentService->createPaymentValidator() );
 		return $newPaymentCreationRequest;
 	}
 

--- a/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -174,7 +174,7 @@ class AddDonationUseCase {
 	 * Modify PaymentCreationRequest from the AddDonationRequest
 	 *
 	 * We need to add donor-type specific properties (bank transfer code and validation)
-	 * to the original request. PaymentCreationRequest is immutable so we create a new one.
+	 * to the original request.
 	 *
 	 * @param AddDonationRequest $request
 	 * @return PaymentCreationRequest
@@ -186,16 +186,11 @@ class AddDonationUseCase {
 			$paymentReferenceCodePrefix = self::PREFIX_BANK_TRANSACTION_ANONYMOUS_DONOR;
 		}
 
-		$newPaymentCreationRequest = new PaymentCreationRequest(
-			$paymentRequest->amountInEuroCents,
-			$paymentRequest->interval,
-			$paymentRequest->paymentType,
-			$paymentRequest->iban,
-			$paymentRequest->bic,
-			$paymentReferenceCodePrefix
-		);
-		$newPaymentCreationRequest->setDomainSpecificPaymentValidator( $this->paymentService->createPaymentValidator() );
-		return $newPaymentCreationRequest;
+		$paymentRequest = PaymentRequestBuilder::fromExistingRequest( $paymentRequest )
+			->withPaymentReferenceCodePrefix( $paymentReferenceCodePrefix )
+			->getPaymentCreationRequest();
+		$paymentRequest->setDomainSpecificPaymentValidator( $this->paymentService->createPaymentValidator() );
+		return $paymentRequest;
 	}
 
 	private function generatePaymentProviderUrl( PaymentProviderURLGenerator $paymentProviderURLGenerator, Donation $donation, DonationTokens $tokens ): string {

--- a/src/UseCases/AddDonation/AddDonationValidationResult.php
+++ b/src/UseCases/AddDonation/AddDonationValidationResult.php
@@ -15,7 +15,6 @@ class AddDonationValidationResult extends ValidationResult {
 
 	public const SOURCE_PAYMENT_TYPE = 'zahlweise';
 	public const SOURCE_PAYMENT_AMOUNT = 'amount';
-
 	public const SOURCE_DONOR_ADDRESS_TYPE = 'addressType';
 	public const SOURCE_DONOR_EMAIL = 'email';
 	public const SOURCE_DONOR_COMPANY = AddressValidator::SOURCE_COMPANY;
@@ -29,17 +28,8 @@ class AddDonationValidationResult extends ValidationResult {
 	public const SOURCE_DONOR_COUNTRY = AddressValidator::SOURCE_COUNTRY;
 	public const SOURCE_TRACKING_SOURCE = 'source';
 
-	public const VIOLATION_TOO_LOW = 'too-low';
-	public const VIOLATION_TOO_HIGH = 'too-high';
+	public const VIOLATION_FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE = 'forbidden_payment_type_for_donor_type';
+
 	public const VIOLATION_WRONG_LENGTH = 'wrong-length';
-	public const VIOLATION_NOT_MONEY = 'not-money';
-	public const VIOLATION_MISSING = 'missing';
-	public const VIOLATION_IBAN_BLOCKED = 'iban-blocked';
-	public const VIOLATION_NOT_DATE = 'not-date';
-	public const VIOLATION_NOT_PHONE_NUMBER = 'not-phone';
-	public const VIOLATION_NOT_EMAIL = 'not-email';
-	public const VIOLATION_NOT_POSTCODE = 'not-postcode';
-	public const VIOLATION_WRONG_PAYMENT_TYPE = 'invalid_payment_type';
-	public const VIOLATION_TEXT_POLICY = 'text_policy';
 
 }

--- a/src/UseCases/AddDonation/CreatePaymentService.php
+++ b/src/UseCases/AddDonation/CreatePaymentService.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse as PaymentCreationFailed;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as PaymentCreationSucceeded;
@@ -11,5 +10,5 @@ use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\SuccessResponse as Pa
 interface CreatePaymentService {
 	public function createPayment( PaymentCreationRequest $request ): PaymentCreationFailed|PaymentCreationSucceeded;
 
-	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator;
+	public function createPaymentValidator(): DonationPaymentValidator;
 }

--- a/src/UseCases/AddDonation/CreatePaymentWithUseCase.php
+++ b/src/UseCases/AddDonation/CreatePaymentWithUseCase.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\CreatePaymentUseCase;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\FailureResponse as PaymentCreationFailed;
@@ -26,8 +25,8 @@ class CreatePaymentWithUseCase implements CreatePaymentService {
 		return $this->createPaymentUseCase->createPayment( $request );
 	}
 
-	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator {
-		return new DonationPaymentValidator( $this->allowedPaymentTypes, $donorType );
+	public function createPaymentValidator(): DonationPaymentValidator {
+		return new DonationPaymentValidator( $this->allowedPaymentTypes );
 	}
 
 }

--- a/src/UseCases/AddDonation/DonationPaymentValidator.php
+++ b/src/UseCases/AddDonation/DonationPaymentValidator.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace WMDE\Fundraising\DonationContext\UseCases\AddDonation;
 
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\PaymentContext\Domain\DomainSpecificPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
@@ -56,11 +55,6 @@ class DonationPaymentValidator implements DomainSpecificPaymentValidator {
 	public const FORBIDDEN_PAYMENT_TYPE = 'forbidden_payment_type';
 
 	/**
-	 * Violation identifier for {@see ConstraintViolation}
-	 */
-	public const FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE = 'forbidden_payment_type_for_donor_type';
-
-	/**
 	 * Error source name for {@see ConstraintViolation}
 	 */
 	public const SOURCE_AMOUNT = 'amount';
@@ -74,8 +68,7 @@ class DonationPaymentValidator implements DomainSpecificPaymentValidator {
 	private Euro $maximumAmount;
 
 	public function __construct(
-		private readonly array $allowedPaymentTypes,
-		private readonly DonorType $donorType
+		private readonly array $allowedPaymentTypes
 	) {
 		$this->minimumAmount = Euro::newFromInt( self::MINIMUM_AMOUNT_IN_EUROS );
 		$this->maximumAmount = Euro::newFromInt( self::MAXIMUM_AMOUNT_IN_EUROS );
@@ -109,12 +102,6 @@ class DonationPaymentValidator implements DomainSpecificPaymentValidator {
 		if ( $amountInCents >= $this->maximumAmount->getEuroCents() ) {
 			return ValidationResponse::newFailureResponse( [
 				new ConstraintViolation( $amountInCents, self::AMOUNT_TOO_HIGH, self::SOURCE_AMOUNT )
-			] );
-		}
-
-		if ( $this->donorType->is( DonorType::ANONYMOUS() ) && $paymentType === PaymentType::DirectDebit ) {
-			return ValidationResponse::newFailureResponse( [
-				new ConstraintViolation( $paymentType->value, self::FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE, self::SOURCE_PAYMENT_TYPE )
 			] );
 		}
 

--- a/src/UseCases/AddDonation/PaymentRequestBuilder.php
+++ b/src/UseCases/AddDonation/PaymentRequestBuilder.php
@@ -18,6 +18,12 @@ class PaymentRequestBuilder {
 		);
 	}
 
+	public static function fromExistingRequest( PaymentCreationRequest $request ): self {
+		$builder = new self();
+		$builder->paymentCreationRequest = $request;
+		return $builder;
+	}
+
 	public function getPaymentCreationRequest(): PaymentCreationRequest {
 		return $this->paymentCreationRequest;
 	}

--- a/src/UseCases/AddDonation/PaymentRequestBuilder.php
+++ b/src/UseCases/AddDonation/PaymentRequestBuilder.php
@@ -80,14 +80,14 @@ class PaymentRequestBuilder {
 		return $this;
 	}
 
-	public function withPaymentReferenceCode( string $paymentReferenceCode ): self {
+	public function withPaymentReferenceCodePrefix( string $transferCodePrefix ): self {
 		$this->paymentCreationRequest = new PaymentCreationRequest(
 			$this->paymentCreationRequest->amountInEuroCents,
 			$this->paymentCreationRequest->interval,
 			$this->paymentCreationRequest->paymentType,
 			$this->paymentCreationRequest->iban,
 			$this->paymentCreationRequest->bic,
-			$paymentReferenceCode
+			$transferCodePrefix
 		);
 		return $this;
 	}

--- a/tests/Data/ValidAddDonationRequest.php
+++ b/tests/Data/ValidAddDonationRequest.php
@@ -9,6 +9,10 @@ use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
 
+/**
+ * A Valid AddDonationRequest with a private person donor, donating
+ * 5 Euros, one time via direct debit.
+ */
 class ValidAddDonationRequest {
 
 	public static function getRequest(): AddDonationRequest {

--- a/tests/Fixtures/CreatePaymentServiceSpy.php
+++ b/tests/Fixtures/CreatePaymentServiceSpy.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 use WMDE\Fundraising\PaymentContext\UseCases\CreatePayment\PaymentCreationRequest;
@@ -20,8 +19,8 @@ class CreatePaymentServiceSpy extends SucceedingPaymentServiceStub {
 		return parent::createPayment( $request );
 	}
 
-	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator {
-		return new DonationPaymentValidator( PaymentType::cases(), $donorType );
+	public function createPaymentValidator(): DonationPaymentValidator {
+		return new DonationPaymentValidator( PaymentType::cases() );
 	}
 
 	public function getLastRequest(): PaymentCreationRequest {

--- a/tests/Fixtures/SucceedingPaymentServiceStub.php
+++ b/tests/Fixtures/SucceedingPaymentServiceStub.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
 
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidPayments;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\CreatePaymentService;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
@@ -28,8 +27,8 @@ class SucceedingPaymentServiceStub implements CreatePaymentService {
 		return $this->successResponse;
 	}
 
-	public function createPaymentValidator( DonorType $donorType ): DonationPaymentValidator {
-		return new DonationPaymentValidator( PaymentType::cases(), $donorType );
+	public function createPaymentValidator(): DonationPaymentValidator {
+		return new DonationPaymentValidator( PaymentType::cases() );
 	}
 
 }

--- a/tests/Unit/UseCases/AddDonation/DonationPaymentValidatorTest.php
+++ b/tests/Unit/UseCases/AddDonation/DonationPaymentValidatorTest.php
@@ -5,7 +5,6 @@ namespace WMDE\Fundraising\DonationContext\Tests\Unit\UseCases\AddDonation;
 
 use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\DonationPaymentValidator;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentInterval;
 use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
@@ -24,7 +23,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	 * @dataProvider getValidAmounts
 	 */
 	public function testGivenValidAmount_validatorReturnsNoViolations( float $amount ): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::PERSON() );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromFloat( $amount ), PaymentInterval::OneTime, PaymentType::DirectDebit );
 
@@ -38,7 +37,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenSmallAmount_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::PERSON() );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromCents( 99 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
 
@@ -50,7 +49,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenLargeAmount_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::PERSON() );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 100_000 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
 
@@ -62,7 +61,7 @@ class DonationPaymentValidatorTest extends TestCase {
 	}
 
 	public function testGivenDisallowedPaymentType_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::COMPANY() );
+		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES );
 
 		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 99 ), PaymentInterval::OneTime, PaymentType::Paypal );
 
@@ -71,25 +70,5 @@ class DonationPaymentValidatorTest extends TestCase {
 			new ConstraintViolation( PaymentType::Paypal->value, DonationPaymentValidator::FORBIDDEN_PAYMENT_TYPE, DonationPaymentValidator::SOURCE_PAYMENT_TYPE ),
 			$validationResult->getValidationErrors()[0]
 		);
-	}
-
-	public function testGivenAnonymousDonorAndDirectDebitPayment_validatorReturnsViolation(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::ANONYMOUS() );
-
-		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 99 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
-
-		$this->assertFalse( $validationResult->isSuccessful() );
-		$this->assertEquals(
-			new ConstraintViolation( PaymentType::DirectDebit->value, DonationPaymentValidator::FORBIDDEN_PAYMENT_TYPE_FOR_DONOR_TYPE, DonationPaymentValidator::SOURCE_PAYMENT_TYPE ),
-			$validationResult->getValidationErrors()[0]
-		);
-	}
-
-	public function testGivenEmailOnlyDonorAndDirectDebitPayment_validatorReturnsValid(): void {
-		$validator = new DonationPaymentValidator( self::ALLOWED_PAYMENT_TYPES, DonorType::EMAIL() );
-
-		$validationResult = $validator->validatePaymentData( Euro::newFromInt( 99 ), PaymentInterval::OneTime, PaymentType::DirectDebit );
-
-		$this->assertTrue( $validationResult->isSuccessful() );
 	}
 }


### PR DESCRIPTION
A followup for #205 that undoes the BC-breaking constructor changes and allows for usage of `DonationPaymentValidator` to just validate payment data (amounts and allowed payment types), even when the donor type is unknown