### PR TITLE
Remove address exists validation from update

### DIFF
--- a/src/UseCases/UpdateDonor/UpdateDonorResponse.php
+++ b/src/UseCases/UpdateDonor/UpdateDonorResponse.php
@@ -14,7 +14,6 @@ class UpdateDonorResponse {
 	public const SUCCESS_TEXT = 'donor_change_success_text';
 	public const ERROR_ACCESS_DENIED = 'donor_change_failure_access_denied';
 	public const ERROR_DONATION_IS_EXPORTED = 'donor_change_failure_exported';
-	public const ERROR_DONATION_HAS_ADDRESS = 'donor_change_failure_has_address';
 	public const ERROR_VALIDATION_FAILED = 'donor_change_failure_validation_error';
 
 	private $donation;

--- a/src/UseCases/UpdateDonor/UpdateDonorUseCase.php
+++ b/src/UseCases/UpdateDonor/UpdateDonorUseCase.php
@@ -62,10 +62,6 @@ class UpdateDonorUseCase {
 			return UpdateDonorResponse::newFailureResponse( UpdateDonorResponse::ERROR_DONATION_IS_EXPORTED );
 		}
 
-		if ( $donation->getDonor()->getPhysicalAddress() instanceof PostalAddress ) {
-			return UpdateDonorResponse::newFailureResponse( UpdateDonorResponse::ERROR_DONATION_HAS_ADDRESS );
-		}
-
 		$validationResult = $this->updateDonorValidator->validateDonorData( $updateDonorRequest );
 		if ( $validationResult->getViolations() ) {
 			// We don't need to return the full validation result since we rely on the client-side validation to catch

--- a/tests/Integration/UseCases/UpdateDonor/UpdateDonorUseCaseTest.php
+++ b/tests/Integration/UseCases/UpdateDonor/UpdateDonorUseCaseTest.php
@@ -75,19 +75,6 @@ class UpdateDonorUseCaseTest extends TestCase {
 		$useCase->updateDonor( $this->newUpdateDonorRequestForPerson( $donationId ) );
 	}
 
-	public function testGivenDonationWithAddressData_donationUpdateFails() {
-		$repository = $this->newRepository();
-		$donation = ValidDonation::newDirectDebitDonation();
-		$repository->storeDonation( $donation );
-		$donationId = $donation->getId();
-
-		$useCase = $this->newUpdateDonorUseCase( $repository );
-		$response = $useCase->updateDonor( $this->newUpdateDonorRequestForPerson( $donationId ) );
-
-		$this->assertFalse( $response->isSuccessful() );
-		$this->assertEquals( UpdateDonorResponse::ERROR_DONATION_HAS_ADDRESS, $response->getErrorMessage() );
-	}
-
 	public function testGivenFailingAuthorizer_donationUpdateFails() {
 		$repository = $this->newRepository();
 		$donation = ValidDonation::newIncompleteAnonymousPayPalDonation();


### PR DESCRIPTION
The application now allows the donor to update their address before export even if they have previously entered one.

Ticket: https://phabricator.wikimedia.org/T316632