### PR TITLE
Fix donation ID migration

### DIFF
--- a/src/DataAccess/DoctrineDonationExistsChecker.php
+++ b/src/DataAccess/DoctrineDonationExistsChecker.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\DataAccess;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityManager;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationExistsChecker;
 
@@ -16,9 +17,11 @@ class DoctrineDonationExistsChecker implements DonationExistsChecker {
 
 	public function donationExists( int $donationId ): bool {
 		$connection = $this->entityManager->getConnection();
-		$count = $connection->prepare( 'SELECT count(*) FROM spenden WHERE id=?' )
-			->executeQuery( [ $donationId ] )
-			->fetchOne();
+		$count = $connection->executeQuery(
+			'SELECT count(*) FROM spenden WHERE id=?',
+			[ $donationId ],
+			[ ParameterType::INTEGER ]
+		)->fetchOne();
 
 		return intval( $count ) === 1;
 	}

--- a/src/DataAccess/Migrations/Version20230613080717.php
+++ b/src/DataAccess/Migrations/Version20230613080717.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
+ * Create table for storing the latest Donation ID
  */
 final class Version20230613080717 extends AbstractMigration {
 
@@ -20,9 +20,11 @@ final class Version20230613080717 extends AbstractMigration {
 		$table = $schema->createTable( 'last_generated_donation_id' );
 		$table->addColumn( 'donation_id', 'integer' );
 		$table->setPrimaryKey( [ 'donation_id' ] );
+	}
 
+	public function postUp( Schema $schema ): void {
 		$this->addSql(
-			'INSERT INTO last_generated_payment_id (donation_id) VALUES ((SELECT MAX(id) + 1 FROM spenden))'
+			'INSERT INTO last_generated_donation_id (donation_id) VALUES ((SELECT MAX(id) FROM spenden))'
 		);
 	}
 

--- a/src/DataAccess/Migrations/Version20230613080717.php
+++ b/src/DataAccess/Migrations/Version20230613080717.php
@@ -17,9 +17,11 @@ final class Version20230613080717 extends AbstractMigration {
 	}
 
 	public function up( Schema $schema ): void {
-		$table = $schema->createTable( 'last_generated_donation_id' );
-		$table->addColumn( 'donation_id', 'integer' );
-		$table->setPrimaryKey( [ 'donation_id' ] );
+		$donationIdTable = $schema->createTable( 'last_generated_donation_id' );
+		$donationIdTable->addColumn( 'donation_id', 'integer' );
+		$donationIdTable->setPrimaryKey( [ 'donation_id' ] );
+		$donationTable = $schema->getTable( 'spenden' );
+		$donationTable->getColumn( 'id' )->setAutoincrement( false );
 	}
 
 	public function postUp( Schema $schema ): void {
@@ -30,5 +32,16 @@ final class Version20230613080717 extends AbstractMigration {
 
 	public function down( Schema $schema ): void {
 		$schema->dropTable( 'last_generated_donation_id' );
+		$this->write( 'Please add back the AUTO_INCREMENT property to spenden.id. You can find instructions in ' . __FILE__ );
+
+		// MySQL/MariaDB will fail to add back the autoincrement by calling
+		// $donationTable->getColumn( 'id' )->setAutoincrement(true)
+		// It fails because the change *could* affect foreign key constraint (to the moderation table)
+		// In reality, that change does *not* affect the constraint, so if you really wanted to undo this migration,
+		// you could run the following SQL commands:
+		//
+		// SET FOREIGN_KEY_CHECKS=0;
+		// ALTER TABLE spenden MODIFY id int(12) NOT NULL AUTO_INCREMENT;
+		// SET FOREIGN_KEY_CHECKS=1;
 	}
 }


### PR DESCRIPTION
This is a followup for #218

Fix wrong table name in SQL when generating the donation ID.
Move data manipulation statements to `postUp` method (to enforce right
order)
Change autogenerated comment to a descriptive one
