### PR TITLE
Allow Payments Bounded Context Version 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/freezable-value-object": "~2.0",
 		"wmde/fun-validators": "~4.0",
-		"wmde/fundraising-payments": "~7.0"
+		"wmde/fundraising-payments": "~7.0|~8.0"
 	},
 	"repositories": [
 		{


### PR DESCRIPTION
This is an "anticipatory" change of for a BC break occurring in the
Payments bounded context that won't affect donations, only the
application (see https://github.com/wmde/fundraising-payments/pull/147 )

This is for https://phabricator.wikimedia.org/T350149
