### PR TITLE
Require coverage metadata in PHPUnit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,17 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+	backupGlobals="false"
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	cacheDirectory=".phpunit.cache"
+	backupStaticProperties="false"
+	requireCoverageMetadata="true" 
+>
   <coverage includeUncoveredFiles="true"/>
   <testsuites>
     <testsuite name="unit">


### PR DESCRIPTION
PHPUnit should check for `@covers` annotations and/or `#CoversClass` PHP
attributes. This change will allow us to disable the check in our coding
style, which only supports annotations. The coding style rule would
block us from using attributes and PHPUnit 11 in the future.

Format PHPUnit config attributes for better readability and easier
diffing.

Ticket: https://phabricator.wikimedia.org/T359971
