### PR TITLE
Preserve some fields when scrubbing personal data

### DIFF
--- a/src/DataAccess/DonorFactory.php
+++ b/src/DataAccess/DonorFactory.php
@@ -22,7 +22,12 @@ class DonorFactory {
 
 		if ( $donation->isScrubbed() ) {
 			$donorType = self::createDonorTypeFromRawAddressType( $rawAddressType );
-			return new ScrubbedDonor( $donorType );
+			return new ScrubbedDonor(
+				new Donor\Name\ScrubbedName( $data->getValue( 'anrede' ) ),
+				$donorType,
+				$donation->getDonorOptsIntoNewsletter(),
+				(bool)$donation->getDonationReceipt()
+			);
 		}
 
 		switch ( $rawAddressType ) {

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use RuntimeException;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\ScrubbedName;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\ScrubbedDonor;
 
 class Donation {
@@ -244,7 +245,12 @@ class Donation {
 				$this->getId()
 			) );
 		}
-		$this->donor = new ScrubbedDonor( $this->donor->getDonorType() );
+		$this->donor = new ScrubbedDonor(
+			new ScrubbedName( $this->donor->getName()->getSalutation() ),
+			$this->donor->getDonorType(),
+			$this->donor->isSubscribedToMailingList(),
+			$this->donor->wantsReceipt()
+		);
 	}
 
 	/**

--- a/src/Domain/Model/Donor/Name/CompanyContactName.php
+++ b/src/Domain/Model/Donor/Name/CompanyContactName.php
@@ -34,6 +34,10 @@ class CompanyContactName implements DonorName {
 		return $name;
 	}
 
+	public function getSalutation(): string {
+		return 'firma';
+	}
+
 	public function toArray(): array {
 		return array_merge( [
 			'companyName' => $this->companyName,

--- a/src/Domain/Model/Donor/Name/CompanyName.php
+++ b/src/Domain/Model/Donor/Name/CompanyName.php
@@ -27,4 +27,8 @@ class CompanyName implements DonorName {
 		return $this->companyName;
 	}
 
+	public function getSalutation(): string {
+		return 'firma';
+	}
+
 }

--- a/src/Domain/Model/Donor/Name/NoName.php
+++ b/src/Domain/Model/Donor/Name/NoName.php
@@ -19,4 +19,8 @@ class NoName implements DonorName {
 		return [];
 	}
 
+	public function getSalutation(): string {
+		return '';
+	}
+
 }

--- a/src/Domain/Model/Donor/Name/PersonName.php
+++ b/src/Domain/Model/Donor/Name/PersonName.php
@@ -42,4 +42,8 @@ class PersonName implements DonorName {
 		);
 	}
 
+	public function getSalutation(): string {
+		return $this->salutation;
+	}
+
 }

--- a/src/Domain/Model/Donor/Name/ScrubbedName.php
+++ b/src/Domain/Model/Donor/Name/ScrubbedName.php
@@ -8,12 +8,20 @@ use WMDE\Fundraising\DonationContext\Domain\Model\DonorName;
 
 class ScrubbedName implements DonorName {
 
+	public function __construct( private readonly string $salutation ) {
+	}
+
 	public function getFullName(): string {
 		return '';
 	}
 
 	public function toArray(): array {
-		return [];
+		return [
+			'salutation' => $this->salutation,
+		];
 	}
 
+	public function getSalutation(): string {
+		return $this->salutation;
+	}
 }

--- a/src/Domain/Model/Donor/ScrubbedDonor.php
+++ b/src/Domain/Model/Donor/ScrubbedDonor.php
@@ -12,14 +12,33 @@ use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
  * This is a donor "placeholder" class for donations that were exported and anonymized.
  *
  * This class is different from {@see AnonymousDonor}, which is the class used where the person has actively
- * declined to provide an address.
+ * declined to provide an address. It preserves certain settings of the original donor.
  */
 class ScrubbedDonor extends AbstractDonor {
+	use MailingListTrait;
+	use ReceiptTrait;
 
-	public function __construct( private readonly DonorType $originalDonorType ) {
-		$this->name = new ScrubbedName();
+	public function __construct(
+		ScrubbedName $name,
+		private readonly DonorType $originalDonorType,
+		bool $mailingListOptIn,
+		bool $requireReceipt
+	) {
+		$this->name = $name;
 		$this->physicalAddress = new ScrubbedAddress();
 		$this->emailAddress = '';
+
+		if ( $mailingListOptIn ) {
+			$this->subscribeToMailingList();
+		} else {
+			$this->unsubscribeFromMailingList();
+		}
+
+		if ( $requireReceipt ) {
+			$this->requireReceipt();
+		} else {
+			$this->declineReceipt();
+		}
 	}
 
 	public function isPrivatePerson(): bool {
@@ -32,30 +51,6 @@ class ScrubbedDonor extends AbstractDonor {
 
 	public function getDonorType(): DonorType {
 		return $this->originalDonorType;
-	}
-
-	public function subscribeToMailingList(): void {
-		// Do nothing, this donor doesn't support newsletters
-	}
-
-	public function unsubscribeFromMailingList(): void {
-		// Do nothing, this donor doesn't support newsletters
-	}
-
-	public function isSubscribedToMailingList(): bool {
-		return false;
-	}
-
-	public function requireReceipt(): void {
-		// Do nothing, this donor doesn't support receipts
-	}
-
-	public function declineReceipt(): void {
-		// Do nothing, this donor doesn't support receipts
-	}
-
-	public function wantsReceipt(): bool {
-		return false;
 	}
 
 }

--- a/src/Domain/Model/DonorName.php
+++ b/src/Domain/Model/DonorName.php
@@ -8,6 +8,8 @@ interface DonorName {
 
 	public function getFullName(): string;
 
+	public function getSalutation(): string;
+
 	/**
 	 * Get name components for usage in templates
 	 *

--- a/tests/Unit/DataAccess/DonorFieldMapperTest.php
+++ b/tests/Unit/DataAccess/DonorFieldMapperTest.php
@@ -73,9 +73,15 @@ class DonorFieldMapperTest extends TestCase {
 		$this->assertSame( ValidDonation::DONOR_CITY, $personalDonation->getDonorCity() );
 	}
 
-	public function testGivenScrubbedDonorItPassesTheOriginalDonorTypeAsForTheAddressType(): void {
-		$fields = DonorFieldMapper::getPersonalDataFields( new Donor\ScrubbedDonor( DonorType::COMPANY ) );
+	public function testGivenScrubbedDonorItPassesTheOriginalDonorTypeAndTitle(): void {
+		$fields = DonorFieldMapper::getPersonalDataFields( new Donor\ScrubbedDonor(
+			new Donor\Name\ScrubbedName( 'Divers' ),
+			DonorType::COMPANY,
+			true,
+			true
+		) );
 
 		$this->assertSame( 'firma', $fields['adresstyp'] );
+		$this->assertSame( 'Divers', $fields['anrede'] );
 	}
 }

--- a/tests/Unit/Domain/Model/ScrubbedDonorTest.php
+++ b/tests/Unit/Domain/Model/ScrubbedDonorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WMDE\Fundraising\DonationContext\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\ScrubbedName;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\ScrubbedDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
+
+#[CoversClass( ScrubbedDonor::class )]
+class ScrubbedDonorTest extends TestCase {
+
+	public function testScrubbedDonorSupportsType(): void {
+		$personDonor = new ScrubbedDonor( new ScrubbedName( 'Herr' ), DonorType::PERSON, false, false );
+		$companyDonor = new ScrubbedDonor( new ScrubbedName( 'Firma' ), DonorType::COMPANY, false, false );
+		$this->assertSame( DonorType::PERSON, $personDonor->getDonorType() );
+		$this->assertSame( DonorType::COMPANY, $companyDonor->getDonorType() );
+	}
+
+	public function testScrubbedDonorSupportsName(): void {
+		$donor = new ScrubbedDonor( new ScrubbedName( 'Frau' ), DonorType::PERSON, false, false );
+		$this->assertSame( 'Frau', $donor->getName()->getSalutation() );
+	}
+
+	public function testScrubbedDonorSupportsMailingListSubscription(): void {
+		$subscribedDonor = new ScrubbedDonor( new ScrubbedName( 'Herr' ), DonorType::PERSON, true, false );
+		$unsubscribedDonor = new ScrubbedDonor( new ScrubbedName( 'Herr' ), DonorType::PERSON, false, false );
+		$this->assertTrue( $subscribedDonor->isSubscribedToMailingList() );
+		$this->assertFalse( $unsubscribedDonor->isSubscribedToMailingList() );
+	}
+
+	public function testScrubbedDonorSupportsReceiptRequirement(): void {
+		$receiptRequiredDonor = new ScrubbedDonor( new ScrubbedName( 'Herr' ), DonorType::PERSON, false, true );
+		$receiptNotRequiredDonor = new ScrubbedDonor( new ScrubbedName( 'Herr' ), DonorType::PERSON, false, false );
+		$this->assertTrue( $receiptRequiredDonor->wantsReceipt() );
+		$this->assertFalse( $receiptNotRequiredDonor->wantsReceipt() );
+	}
+}


### PR DESCRIPTION
We need to preserve
- Mailing List Subscription
- Receipt wanted
- Salutation

for analysis in the Fundraising Operation Center. This commit fixes
an error where the analysis of "how many people subscribed to the
mailing list" dropped to 0 after scrubbing.
