### PR TITLE
Improve exception messages

### DIFF
--- a/src/DataAccess/DoctrineDonationRepository.php
+++ b/src/DataAccess/DoctrineDonationRepository.php
@@ -113,7 +113,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		try {
 			return $converter->createFromLegacyObject( $doctrineDonation );
 		} catch ( \InvalidArgumentException $ex ) {
-			throw new GetDonationException( $ex, "Could not get donation with id '$id'" );
+			throw new GetDonationException( $ex, "Could not convert donation with id '$id' - " . $ex->getMessage() );
 		}
 	}
 }


### PR DESCRIPTION
This commit disambiguates the exception messages when getting a
donation. When a donation can be loaded but the conversion to a domain
object fails, the message no longer reads "could not get donation" (that
would hint at the donation not being in the database).

Ticket: https://phabricator.wikimedia.org/T375196
