### PR TITLE
Fix PayPal notification errors

### DIFF
--- a/src/DataAccess/DonorFactory.php
+++ b/src/DataAccess/DonorFactory.php
@@ -85,7 +85,7 @@ class DonorFactory {
 			'firma' => DonorType::COMPANY,
 			'email' => DonorType::EMAIL,
 			'person' => DonorType::PERSON,
-			'anonymous' => DonorType::ANONYMOUS,
+			'anonym' => DonorType::ANONYMOUS,
 			default => throw new \InvalidArgumentException( sprintf( 'Unknown donor type: %s', $addressType ) ),
 		};
 	}

--- a/src/DataAccess/DonorFieldMapper.php
+++ b/src/DataAccess/DonorFieldMapper.php
@@ -5,12 +5,12 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\DonationContext\DataAccess;
 
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation as DoctrineDonation;
+use WMDE\Fundraising\DonationContext\DataAccess\LegacyConverters\DonorTypeConverter;
 use WMDE\Fundraising\DonationContext\Domain\Model\Address;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Address\NoAddress;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\DonorName;
-use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 
 /**
  * Convert a Donor into an array of fields for the legacy database schema that
@@ -27,7 +27,7 @@ class DonorFieldMapper {
 			// Order of the fields is the same as the resulting array of ValidDoctrineDonation,
 			// otherwise comparing the serialized data will fail
 			[
-				'adresstyp' => self::getAddressType( $donor ),
+				'adresstyp' => DonorTypeConverter::getLegacyDonorType( $donor->getDonorType() ),
 			],
 			self::getDataFieldsFromPersonName( $donor->getName() ),
 			self::getDataFieldsFromAddress( $donor->getPhysicalAddress() ),
@@ -94,16 +94,6 @@ class DonorFieldMapper {
 		}
 
 		$doctrineDonation->setDonorCity( $donor->getPhysicalAddress()->getCity() );
-	}
-
-	private static function getAddressType( Donor $donor ): string {
-		$donorType = $donor->getDonorType();
-		return match ( $donorType ) {
-			DonorType::PERSON => 'person',
-			DonorType::COMPANY => 'firma',
-			DonorType::EMAIL => 'email',
-			DonorType::ANONYMOUS => 'anonym'
-		};
 	}
 
 }

--- a/src/DataAccess/LegacyConverters/DonorTypeConverter.php
+++ b/src/DataAccess/LegacyConverters/DonorTypeConverter.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess\LegacyConverters;
+
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
+
+/**
+ * This class translates between the Domain class {@see DonorType} and the "adresstyp" key in the "data blob" of
+ * the Doctrine {@see \WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation} entity.
+ */
+class DonorTypeConverter {
+	public static function getLegacyDonorType( DonorType $donorType ): string {
+		return match ( $donorType ) {
+			DonorType::PERSON => 'person',
+			DonorType::COMPANY => 'firma',
+			DonorType::EMAIL => 'email',
+			DonorType::ANONYMOUS => 'anonym'
+		};
+	}
+
+	public static function getDonorTypeFromString( string $donorType ): DonorType {
+		return match ( $donorType ) {
+			'firma' => DonorType::COMPANY,
+			'email' => DonorType::EMAIL,
+			'person' => DonorType::PERSON,
+			'anonym' => DonorType::ANONYMOUS,
+			default => throw new \InvalidArgumentException( sprintf( 'Unknown donor type: %s', $donorType ) ),
+		};
+	}
+}

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -110,7 +110,7 @@ class ValidDoctrineDonation {
 		return $donation;
 	}
 
-	public static function newAnyonymizedDonation(): Donation {
+	public static function newScrubbedDonation(): Donation {
 		$self = new self();
 		$donation = $self->createDonation();
 		$donation->setPaymentType( self::PAYMENT_PAYPAL );
@@ -127,6 +127,7 @@ class ValidDoctrineDonation {
 		);
 		$donation->setDonorCity( '' );
 		$donation->setDonorEmail( '' );
+		$donation->scrub();
 		return $donation;
 	}
 

--- a/tests/Unit/DataAccess/DonorFactoryTest.php
+++ b/tests/Unit/DataAccess/DonorFactoryTest.php
@@ -9,6 +9,8 @@ use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\CompanyDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\EmailDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\PersonDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\ScrubbedDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDoctrineDonation;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
 
@@ -42,10 +44,11 @@ class DonorFactoryTest extends TestCase {
 		$this->assertEquals( ValidDonation::newEmailOnlyDonor(), $donor );
 	}
 
-	public function testCreatePrivateAnonymizedDonor(): void {
-		$donor = DonorFactory::createDonorFromEntity( ValidDoctrineDonation::newAnyonymizedDonation() );
+	public function testCreatePrivateScrubbedDonor(): void {
+		$donor = DonorFactory::createDonorFromEntity( ValidDoctrineDonation::newScrubbedDonation() );
 
-		$this->assertInstanceOf( PersonDonor::class, $donor );
+		$this->assertInstanceOf( ScrubbedDonor::class, $donor );
+		$this->assertSame( DonorType::PERSON, $donor->getDonorType() );
 		$this->assertSame( '', $donor->getName()->getFullName() );
 	}
 

--- a/tests/Unit/DataAccess/DonorFactoryTest.php
+++ b/tests/Unit/DataAccess/DonorFactoryTest.php
@@ -52,6 +52,33 @@ class DonorFactoryTest extends TestCase {
 		$this->assertSame( '', $donor->getName()->getFullName() );
 	}
 
+	public function testCreateCompanyScrubbedDonor(): void {
+		$donation = ValidDoctrineDonation::newCompanyDonation();
+		$donation->scrub();
+		$donor = DonorFactory::createDonorFromEntity( $donation );
+
+		$this->assertInstanceOf( ScrubbedDonor::class, $donor );
+		$this->assertSame( DonorType::COMPANY, $donor->getDonorType() );
+	}
+
+	public function testCreateEmailScrubbedDonor(): void {
+		$donation = ValidDoctrineDonation::newEmailDonation();
+		$donation->scrub();
+		$donor = DonorFactory::createDonorFromEntity( $donation );
+
+		$this->assertInstanceOf( ScrubbedDonor::class, $donor );
+		$this->assertSame( DonorType::EMAIL, $donor->getDonorType() );
+	}
+
+	public function testCreateAnonymousScrubbedDonor(): void {
+		$donation = ValidDoctrineDonation::newAnonymousDonation();
+		$donation->scrub();
+		$donor = DonorFactory::createDonorFromEntity( $donation );
+
+		$this->assertInstanceOf( ScrubbedDonor::class, $donor );
+		$this->assertSame( DonorType::ANONYMOUS, $donor->getDonorType() );
+	}
+
 	public function testUnknownAddressTypeThrowsException(): void {
 		$doctrineDonation = ValidDoctrineDonation::newAnonymousDonation();
 		$doctrineDonation->encodeAndSetData( [ 'adresstyp' => 'unknown' ] );


### PR DESCRIPTION
The errors were coming from a wrong string expectation ("anonymous" vs "anonym") in our code. This PR improves the tests to catch the error, fixes the string comparison and moves the conversion between domain object `DonorType` and legacy database field `adresstyp` into a class.

Ticket: https://phabricator.wikimedia.org/T375196
