### PR TITLE
Create constant for anonymous names

### DIFF
--- a/src/Domain/Model/Donor/Name/NoName.php
+++ b/src/Domain/Model/Donor/Name/NoName.php
@@ -11,8 +11,18 @@ use WMDE\Fundraising\DonationContext\Domain\Model\DonorName;
  */
 class NoName implements DonorName {
 
+	/**
+	 * The name displayed in {@see self::getFullName()}
+	 *
+	 * For historical reasons, this is German and won't follow our translation key rules (kebab-case) in the foreseeable future.
+	 * You can use it as a translation key in the frontend, though.
+	 *
+	 * This is mostly used for displaying the confirmation page and when creating comments.
+	 */
+	public const DISPLAY_NAME = 'Anonym';
+
 	public function getFullName(): string {
-		return 'Anonym';
+		return self::DISPLAY_NAME;
 	}
 
 	public function toArray(): array {


### PR DESCRIPTION
With this change, we can access the "display name" of anonymous
donors in our tests. It is one of the last places where we don't use
a domain-specific, translateable placeholder but a German word.
