### PR TITLE
Add backup class for personal data

### DIFF
--- a/src/DataAccess/Backup/DatabaseBackupClient.php
+++ b/src/DataAccess/Backup/DatabaseBackupClient.php
@@ -1,0 +1,20 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess\Backup;
+
+/**
+ * The backup client is responsible for getting the data out of the database and writing it somewhere.
+ *
+ * The donation bounded context only exposes the interface, the actual implementation
+ * (e.g. with `shell_exec` calling `mysqldump`, etc.) is in the Fundraising Operation Center
+ */
+interface DatabaseBackupClient {
+	/**
+	 * @param TableBackupConfiguration ...$tableBackupConfigurations At least one table configuration.
+	 *          The client implementation can decide to write all table output into one file or to split
+	 *          them into individual files.
+	 * @return void
+	 */
+	public function backupDonationTables( TableBackupConfiguration ...$tableBackupConfigurations ): void;
+}

--- a/src/DataAccess/Backup/PersonalDataBackup.php
+++ b/src/DataAccess/Backup/PersonalDataBackup.php
@@ -1,0 +1,45 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess\Backup;
+
+use Doctrine\ORM\EntityManager;
+use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation;
+
+/**
+ * A class to back up the personal data of Donors (to a short-tem intermediate storage).
+ *
+ * This class should be called for production data before scrubbing them from the database with
+ * {@see \WMDE\Fundraising\DonationContext\Domain\DonationAnonymizer}
+ */
+class PersonalDataBackup {
+	public function __construct(
+		private readonly DatabaseBackupClient $backupClient,
+		private readonly EntityManager $entityManager
+	) {
+	}
+
+	public function doBackup( \DateTimeImmutable $backupTime ): int {
+		// The backup client will use `mysqldump` internally and may process the result further
+		$this->backupClient->backupDonationTables(
+			new TableBackupConfiguration( 'spenden', 'is_scrubbed=0 AND dt_backup IS NULL' )
+		);
+
+		// Mark affected donations by setting their backup time.
+		// Make sure the conditions always match the conditions passed to the backup client!
+		$qb = $this->entityManager->createQueryBuilder();
+		$qb->update( Donation::class, 'd' )
+			->set( 'd.dtBackup', ':backupTime' )
+			->where( 'd.isScrubbed=false' )
+			->andWhere( 'd.dtBackup IS NULL' )
+			->setParameter( 'backupTime', $backupTime );
+		/** @var int $affectedRows */
+		$affectedRows = $qb->getQuery()->execute();
+
+		// Clear all lingering entities, they don't get changed by the update query
+		// See https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/dql-doctrine-query-language.html#update-queries
+		$this->entityManager->clear();
+
+		return $affectedRows;
+	}
+}

--- a/src/DataAccess/Backup/TableBackupConfiguration.php
+++ b/src/DataAccess/Backup/TableBackupConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\DataAccess\Backup;
+
+class TableBackupConfiguration {
+
+	/**
+	 * @param string $tableName A database table name
+	 * @param string $conditions SQL conditions to select the data that should be backed up from the table. Can be empty for "all data".
+	 */
+	public function __construct(
+		public readonly string $tableName,
+		public readonly string $conditions
+	) {
+	}
+}

--- a/tests/Fixtures/DatabaseBackupClientSpy.php
+++ b/tests/Fixtures/DatabaseBackupClientSpy.php
@@ -1,0 +1,32 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Fixtures;
+
+use WMDE\Fundraising\DonationContext\DataAccess\Backup\DatabaseBackupClient;
+use WMDE\Fundraising\DonationContext\DataAccess\Backup\TableBackupConfiguration;
+
+class DatabaseBackupClientSpy implements DatabaseBackupClient {
+	/**
+	 * @var TableBackupConfiguration[]
+	 */
+	private ?array $tableBackupConfigurations = null;
+
+	public function backupDonationTables( TableBackupConfiguration ...$backupConfigurations ): void {
+		if ( $this->tableBackupConfigurations !== null ) {
+			throw new \LogicException( "backupTable must only be called once!" );
+		}
+		$this->tableBackupConfigurations = $backupConfigurations;
+	}
+
+	/**
+	 * @return TableBackupConfiguration[]
+	 */
+	public function getTableBackupConfigurations(): array {
+		if ( $this->tableBackupConfigurations === null ) {
+			throw new \LogicException( 'backupTable was never called!' );
+		}
+		return $this->tableBackupConfigurations;
+	}
+
+}

--- a/tests/Integration/DataAccess/PersonalDataBackupTest.php
+++ b/tests/Integration/DataAccess/PersonalDataBackupTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\DonationContext\Tests\Integration\DataAccess;
+
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\DonationContext\DataAccess\Backup\DatabaseBackupClient;
+use WMDE\Fundraising\DonationContext\DataAccess\Backup\PersonalDataBackup;
+use WMDE\Fundraising\DonationContext\DataAccess\Backup\TableBackupConfiguration;
+use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation;
+use WMDE\Fundraising\DonationContext\Tests\Data\ValidDoctrineDonation;
+use WMDE\Fundraising\DonationContext\Tests\Fixtures\DatabaseBackupClientSpy;
+use WMDE\Fundraising\DonationContext\Tests\TestEnvironment;
+
+#[CoversClass( PersonalDataBackup::class )]
+class PersonalDataBackupTest extends TestCase {
+	private const string BACKUP_TIME = '2025-03-04 0:00:00';
+
+	public function testBackupClientIsCalledWithTableNameAndConditionsForDonors(): void {
+		$backupClientSpy = new DatabaseBackupClientSpy();
+		$personalBackup = $this->givenPersonalBackup( backupClient: $backupClientSpy );
+
+		$personalBackup->doBackup( $this->givenBackupTime() );
+
+		$backupConfigurations = $backupClientSpy->getTableBackupConfigurations();
+		$this->assertCount( 1, $backupConfigurations );
+		$this->assertEquals(
+			new TableBackupConfiguration( 'spenden', 'is_scrubbed=0 AND dt_backup IS NULL' ),
+			$backupConfigurations[0]
+		);
+	}
+
+	public function testDonationsGetMarkedWithBackupDate(): void {
+		$factory = TestEnvironment::newInstance()->getFactory();
+		$em = $factory->getEntityManager();
+		$this->givenDonations( $em );
+		$personalBackup = $this->givenPersonalBackup( entityManager: $em );
+		$backupTime = $this->givenBackupTime();
+
+		$personalBackup->doBackup( $backupTime );
+
+		$qb = $em->createQueryBuilder();
+		$qb->select( 'COUNT(d) AS updated_donations' )
+			->from( Donation::class, 'd' )
+			->where( 'd.dtBackup=:backupTime' )
+			->setParameter( 'backupTime', $backupTime->format( 'Y-m-d H:i:s' ) );
+		$this->assertSame( [ [ 'updated_donations' => 3 ] ], $qb->getQuery()->getScalarResult() );
+	}
+
+	public function testDoBackupReturnsNumberOfAffectedItems(): void {
+		$factory = TestEnvironment::newInstance()->getFactory();
+		$em = $factory->getEntityManager();
+		$this->givenDonations( $em );
+		$personalBackup = $this->givenPersonalBackup( entityManager: $em );
+
+		$affectedItems = $personalBackup->doBackup( $this->givenBackupTime() );
+
+		$this->assertSame( 3, $affectedItems );
+	}
+
+	private function givenDonations( EntityManager $entityManager ): void {
+		// Insert 3 donations without backup marker
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$donation = ValidDoctrineDonation::newExportedirectDebitDoctrineDonation();
+			$donation->setId( $i );
+			$entityManager->persist( $donation );
+		}
+
+		// Insert 2 donations with backup marker (i.e. they have been backed up previously)
+		$backupTime = new \DateTime();
+		for ( $i = 4; $i <= 6; $i++ ) {
+			$donation = ValidDoctrineDonation::newExportedirectDebitDoctrineDonation();
+			$donation->setDtBackup( $backupTime );
+			$donation->setId( $i );
+			$entityManager->persist( $donation );
+			$backupTime->modify( '+1 day' );
+		}
+
+		$entityManager->flush();
+	}
+
+	private function givenBackupTime(): \DateTimeImmutable {
+		return new \DateTimeImmutable( self::BACKUP_TIME );
+	}
+
+	private function givenPersonalBackup( ?DatabaseBackupClientSpy $backupClient = null, ?EntityManager $entityManager = null ): PersonalDataBackup {
+		$backupClient = $backupClient ?? $this->createStub( DatabaseBackupClient::class );
+		if ( $entityManager === null ) {
+			$factory = TestEnvironment::newInstance()->getFactory();
+			$entityManager = $factory->getEntityManager();
+		}
+		return new PersonalDataBackup( $backupClient, $entityManager );
+	}
+}


### PR DESCRIPTION
Before scrubbing the personal data from the database, we want to write
it to an encrypted short-term storage, to be able to restore it in cases
when scrubbing goes awry.

This code introduces a class, `PersonalDataBackup` that calls a
`DatabaseBackupClient` interface for writing the data and then marks the
exported data with a date. The actual implementation of the
`DatabaseBackupClient` will be done by the Fundraising Operation Center.

Ticket: https://phabricator.wikimedia.org/T372790
