### PR TITLE
Deprecate more access tokens donation methods

### DIFF
--- a/src/DataAccess/DoctrineEntities/Donation.php
+++ b/src/DataAccess/DoctrineEntities/Donation.php
@@ -456,8 +456,6 @@ class Donation {
 	}
 
 	/**
-	 * NOTE: if possible, use @see getDataObject instead, as it provides a nicer API.
-	 *
 	 * @return array<string,mixed>
 	 */
 	public function getDecodedData(): array {
@@ -471,8 +469,6 @@ class Donation {
 	}
 
 	/**
-	 * NOTE: if possible, use @see modifyDataObject instead, as it provides a nicer API.
-	 *
 	 * @param array<string,mixed> $data
 	 */
 	public function encodeAndSetData( array $data ): void {
@@ -526,6 +522,7 @@ class Donation {
 
 	/**
 	 * @param callable $modificationFunction Takes a modifiable DonationData parameter
+	 * @deprecated The access tokens have been removed from the blob. You should set this information using the AuthenticationToken entity in the Application or Op Center
 	 */
 	public function modifyDataObject( callable $modificationFunction ): void {
 		$dataObject = $this->getDataObject();

--- a/src/DataAccess/DonationData.php
+++ b/src/DataAccess/DonationData.php
@@ -4,6 +4,10 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\DataAccess;
 
+/**
+ * @deprecated The access tokens are an HTTP layer detail that does not belong in the domain.
+ *             You should access this information using the AuthenticationToken entity in the Application or Op Center.
+ */
 class DonationData {
 
 	private ?string $accessToken = null;


### PR DESCRIPTION
- Deprecate `DonationData` class - is name hinted at doing more than just
  storing auth tokens, but it never did more.
- Remove usage hints for data blob accessors.
- Deprecate `modifyDataObject`

This is a followup for #296

Ticket: https://phabricator.wikimedia.org/T390844
