### PR TITLE
Make tracking nullable

### DIFF
--- a/config/DoctrineClassMapping/WMDE.Fundraising.DonationContext.DataAccess.DoctrineEntities.Donation.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.DonationContext.DataAccess.DoctrineEntities.Donation.dcm.xml
@@ -118,7 +118,7 @@
     </many-to-many>
 
     <many-to-one field="donationTracking" target-entity="DonationTracking">
-      <join-column name="tracking_id" referenced-column-name="id" />
+      <join-column name="tracking_id" referenced-column-name="id" nullable="true" />
     </many-to-one>
   </entity>
 </doctrine-mapping>

--- a/src/DataAccess/DoctrineEntities/Donation.php
+++ b/src/DataAccess/DoctrineEntities/Donation.php
@@ -136,7 +136,7 @@ class Donation {
 
 	private int $paymentId;
 
-	private DonationTracking $donationTracking;
+	private ?DonationTracking $donationTracking = null;
 
 	private int $impressionCount = 0;
 
@@ -553,7 +553,7 @@ class Donation {
 		$this->isScrubbed = true;
 	}
 
-	public function getDonationTracking(): DonationTracking {
+	public function getDonationTracking(): ?DonationTracking {
 		return $this->donationTracking;
 	}
 

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -28,9 +28,6 @@ class Donation {
 	private ?DateTimeImmutable $exportDate;
 
 	/**
-	 * TODO: move out of Donation when database model is refactored
-	 * https://phabricator.wikimedia.org/T203679
-	 *
 	 * @var DonationTrackingInfo
 	 */
 	private DonationTrackingInfo $trackingInfo;


### PR DESCRIPTION
Some donations don't have tracking information. To avoid a "magic" value
in the tracking database with empty strings, we need to make the missing
tracking information explicit.

Ticket: https://phabricator.wikimedia.org/T336848
