### PR TITLE
Introduce CODEOWNERS, remove deprecated reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This marks the default owner group of all files in this repository
+*	@wmde/funtech-core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    reviewers:
-      - "wmde/funtech-core"


### PR DESCRIPTION
Dependabot has deprecated the `reviewers` key and wants a `CODEOWNERS` file instead.

See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Ticket: https://phabricator.wikimedia.org/T393569
