### PR TITLE
Stop anonymising donations older than 2 days

### DIFF
--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\DonationContext\Tests\Data;
 
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation;
+use WMDE\Fundraising\DonationContext\Domain\Model\ModerationIdentifier;
+use WMDE\Fundraising\DonationContext\Domain\Model\ModerationReason;
 
 class ValidDoctrineDonation {
 	private const DONATION_ID = 1;
@@ -128,6 +130,20 @@ class ValidDoctrineDonation {
 		$donation->setDonorCity( '' );
 		$donation->setDonorEmail( '' );
 		$donation->scrub();
+		return $donation;
+	}
+
+	public static function newModeratedForAmountTooHighDonation(): Donation {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setModerationReasons( new ModerationReason( ModerationIdentifier::AMOUNT_TOO_HIGH, 'amount' ) );
+		return $donation;
+	}
+
+	public static function newModeratedForContentViolationDonation(): Donation {
+		$self = new self();
+		$donation = $self->createDonation();
+		$donation->setModerationReasons( new ModerationReason( ModerationIdentifier::ADDRESS_CONTENT_VIOLATION, 'firstName' ) );
 		return $donation;
 	}
 

--- a/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
@@ -46,6 +46,10 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 	}
 
 	public function testAnonymizeAllReturnsNumberOfAnonymizedDonations(): void {
+		$this->markTestSkipped( 'This tests that donations that are moderated for high amounts and older than 2 days do not get exported, but others that' .
+			' donations moderated for other reasons do. We currently do not anonymise donations over 2 days so this test will fail' );
+
+		// @phpstan-ignore-next-line
 		$this->insertExampleDonations();
 		$anonymizer = new DatabaseDonationAnonymizer( $this->donationRepository, $this->entityManager, $this->clock, $this->gracePeriod );
 
@@ -53,6 +57,16 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 		$this->assertSame( 5, $count );
 		$this->assertNumberOfScrubbedDonations( 6 );
+	}
+
+	public function testAnonymizeAllReturnsNumberOfAnonymizedDonations_andDoesntAnonymizeDonationsMoreThanTwoDaysOld(): void {
+		$this->insertExampleDonations();
+		$anonymizer = new DatabaseDonationAnonymizer( $this->donationRepository, $this->entityManager, $this->clock, $this->gracePeriod );
+
+		$count = $anonymizer->anonymizeAll();
+
+		$this->assertSame( 3, $count );
+		$this->assertNumberOfScrubbedDonations( 4 );
 	}
 
 	public function testGivenDonation_anonymizeWillAnonymizeIt(): void {


### PR DESCRIPTION
When a donation is marked as moderated for a too high
amount it needs to be manually validated. If this doesn't
happen within 2 days it gets anonymised.

This adds a filter that stops this anonymisation happening
until it is processed.

Ticket: https://phabricator.wikimedia.org/T400323

We shouldn't merge this until we've discussed the process with the entire team.