### PR TITLE
Simplify donation data scrubbing

### DIFF
--- a/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
@@ -51,8 +51,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 		$count = $anonymizer->anonymizeAll();
 
-		$this->assertSame( 4, $count );
-		$this->assertNumberOfScrubbedDonations( 5 );
+		$this->assertSame( 3, $count );
+		$this->assertNumberOfScrubbedDonations( 4 );
 	}
 
 	public function testGivenDonation_anonymizeWillAnonymizeIt(): void {
@@ -130,6 +130,7 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		$this->entityManager->persist( $this->newExportedDonation( 3 ) );
 
 		// Insert un-exported donation that is older than two days, that should also be scrubbed
+		// This does not work, only when https://phabricator.wikimedia.org/T401247 is implemented
 		$threeDaysAgo = \DateTime::createFromImmutable( $this->clock->now()->modify( '-3 days' ) );
 		$this->entityManager->persist( $this->newUnExportedDonation( 4, $threeDaysAgo ) );
 


### PR DESCRIPTION
This commit removes a condition that has led to data loss in the past
(scrubbing moderated donations, scrubbing unexported donations when the
export script was broken).
The new, simplified condition leaves "abandoned" and deleted donations
un-scrubbed, but we're planning to change that in
https://phabricator.wikimedia.org/T401247
