### PR TITLE
Extend scrubbing query

### DIFF
--- a/src/DataAccess/DatabaseDonationAnonymizer.php
+++ b/src/DataAccess/DatabaseDonationAnonymizer.php
@@ -33,7 +33,7 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 	}
 
 	public function anonymizeWithIds( int ...$donationIds ): void {
-		$exportCutoffDate = $this->clock->now()->sub( $this->exportGracePeriod );
+		$externalIncompleteCutoffDate = $this->clock->now()->sub( $this->exportGracePeriod );
 		$moderationCutoffDate = $this->clock->now()->sub( $this->moderationGracePeriod );
 		$counter = 0;
 		foreach ( $donationIds as $id ) {
@@ -41,7 +41,7 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 			if ( $donation === null ) {
 				throw new AnonymizationException( "Could not find donation with id $id" );
 			}
-			$donation->scrubPersonalData( $exportCutoffDate, $moderationCutoffDate );
+			$donation->scrubPersonalData( $externalIncompleteCutoffDate, $moderationCutoffDate );
 			$this->donationRepository->storeDonation( $donation );
 
 			$counter++;
@@ -52,8 +52,15 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 		}
 	}
 
+	/**
+	 * @return int amount of successfully scrubbed and re-written donations
+	 * @throws \DateInvalidOperationException
+	 * @throws \Doctrine\ORM\Exception\ORMException
+	 * @throws \Doctrine\ORM\OptimisticLockException
+	 */
 	public function anonymizeAll(): int {
-		$cutoffDate = $this->clock->now()->sub( $this->exportGracePeriod );
+		$cutoffDateExternalIncomplete = $this->clock->now()->sub( $this->exportGracePeriod );
+		$cutoffDateModeration = $this->clock->now()->sub( $this->moderationGracePeriod );
 
 		$qb = $this->entityManager->createQueryBuilder();
 		$qb->select( 'd' )
@@ -69,22 +76,23 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 				// scrub all deleted donations
 				$qb->expr()->eq( 'd.status', ':deletedStatusFlag' ),
 
-				// scrub "abandoned" donations with incomplete external payments (outside of grace period)
+				// scrub donations with incomplete external payments and are older than the grace period
 				$qb->expr()->andX(
 					$qb->expr()->eq( 'd.status', ':externalIncompletePaymentStatusFlag' ),
-					$qb->expr()->lte( 'd.creationTime', ':cutoffDate' )
+					$qb->expr()->lte( 'd.creationTime', ':cutoffDateExternalIncomplete' )
 				),
 
-				// scrub "abandoned" donations that got flagged for moderation (outside of grace period)
+				// scrub donations that were flagged for moderation and are older than the grace period
 				$qb->expr()->andX(
 					$qb->expr()->eq( 'd.status', ':moderatedStatusFlag' ),
-					$qb->expr()->lte( 'd.creationTime', ':cutoffDate' )
+					$qb->expr()->lte( 'd.creationTime', ':cutoffDateModeration' )
 				)
 			) )
-			->setParameter( 'deletedStatusFlag', 'D', Types::STRING )
-			->setParameter( 'externalIncompletePaymentStatusFlag', 'X', Types::STRING )
-			->setParameter( 'moderatedStatusFlag', 'P', Types::STRING )
-			->setParameter( 'cutoffDate', $cutoffDate );
+			->setParameter( 'deletedStatusFlag', Donation::STATUS_CANCELLED, Types::STRING )
+			->setParameter( 'externalIncompletePaymentStatusFlag', Donation::STATUS_EXTERNAL_INCOMPLETE, Types::STRING )
+			->setParameter( 'moderatedStatusFlag', Donation::STATUS_MODERATION, Types::STRING )
+			->setParameter( 'cutoffDateExternalIncomplete', $cutoffDateExternalIncomplete )
+			->setParameter( 'cutoffDateModeration', $cutoffDateModeration );
 
 		/** @var iterable<Donation> $donations */
 		$donations = $qb->getQuery()->toIterable();
@@ -94,7 +102,7 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 
 		foreach ( $donations as $doctrineDonation ) {
 			$donation = $converter->createFromLegacyObject( $doctrineDonation );
-			$donation->scrubPersonalData( $cutoffDate );
+			$donation->scrubPersonalData( $cutoffDateExternalIncomplete, $cutoffDateModeration );
 			$this->donationRepository->storeDonation( $donation );
 			$count++;
 

--- a/src/DataAccess/DatabaseDonationAnonymizer.php
+++ b/src/DataAccess/DatabaseDonationAnonymizer.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace WMDE\Fundraising\DonationContext\DataAccess;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManager;
 use WMDE\Clock\Clock;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation;
@@ -52,16 +53,29 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 	public function anonymizeAll(): int {
 		$cutoffDate = $this->clock->now()->sub( $this->exportGracePeriod );
 
-		// The following query only scrubs exported donations
-		// We need to add statements to
-		//   - scrub donations with abandoned external payments (using `$cutoffDate`)
-		//   - scrub deleted donations
-		// See https://phabricator.wikimedia.org/T401247
 		$qb = $this->entityManager->createQueryBuilder();
 		$qb->select( 'd' )
 			->from( Donation::class, 'd' )
+
 			->where( 'd.isScrubbed = 0' )
-			->andWhere(	$qb->expr()->isNotNull( 'd.dtGruen' ) );
+
+			->andWhere(	$qb->expr()->orX(
+
+				// scrub all already exported donations
+				$qb->expr()->isNotNull( 'd.dtGruen' ),
+
+				// scrub all deleted donations
+				$qb->expr()->eq( 'd.status', ':deletedStatusFlag' ),
+
+				// scrub "abandoned" donations with incomplete external payments (within grace period)
+				$qb->expr()->andX(
+					$qb->expr()->eq( 'd.status', ':externalIncompletePaymentStatusFlag' ),
+					$qb->expr()->lte( 'd.creationTime', ':cutoffDate' )
+				)
+			) )
+			->setParameter( 'deletedStatusFlag', 'D', Types::STRING )
+			->setParameter( 'externalIncompletePaymentStatusFlag', 'X', Types::STRING )
+			->setParameter( 'cutoffDate', $cutoffDate );
 
 		/** @var iterable<Donation> $donations */
 		$donations = $qb->getQuery()->toIterable();

--- a/src/DataAccess/DatabaseDonationAnonymizer.php
+++ b/src/DataAccess/DatabaseDonationAnonymizer.php
@@ -69,14 +69,21 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 				// scrub all deleted donations
 				$qb->expr()->eq( 'd.status', ':deletedStatusFlag' ),
 
-				// scrub "abandoned" donations with incomplete external payments (within grace period)
+				// scrub "abandoned" donations with incomplete external payments (outside of grace period)
 				$qb->expr()->andX(
 					$qb->expr()->eq( 'd.status', ':externalIncompletePaymentStatusFlag' ),
+					$qb->expr()->lte( 'd.creationTime', ':cutoffDate' )
+				),
+
+				// scrub "abandoned" donations that got flagged for moderation (outside of grace period)
+				$qb->expr()->andX(
+					$qb->expr()->eq( 'd.status', ':moderatedStatusFlag' ),
 					$qb->expr()->lte( 'd.creationTime', ':cutoffDate' )
 				)
 			) )
 			->setParameter( 'deletedStatusFlag', 'D', Types::STRING )
 			->setParameter( 'externalIncompletePaymentStatusFlag', 'X', Types::STRING )
+			->setParameter( 'moderatedStatusFlag', 'P', Types::STRING )
 			->setParameter( 'cutoffDate', $cutoffDate );
 
 		/** @var iterable<Donation> $donations */

--- a/src/DataAccess/DatabaseDonationAnonymizer.php
+++ b/src/DataAccess/DatabaseDonationAnonymizer.php
@@ -27,19 +27,21 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 		private readonly DonationRepository $donationRepository,
 		private readonly EntityManager $entityManager,
 		private readonly Clock $clock,
-		private readonly \DateInterval $exportGracePeriod
+		private readonly \DateInterval $exportGracePeriod,
+		private readonly \DateInterval $moderationGracePeriod
 	) {
 	}
 
 	public function anonymizeWithIds( int ...$donationIds ): void {
-		$cutoffDate = $this->clock->now()->sub( $this->exportGracePeriod );
+		$exportCutoffDate = $this->clock->now()->sub( $this->exportGracePeriod );
+		$moderationCutoffDate = $this->clock->now()->sub( $this->moderationGracePeriod );
 		$counter = 0;
 		foreach ( $donationIds as $id ) {
 			$donation = $this->donationRepository->getDonationById( $id );
 			if ( $donation === null ) {
 				throw new AnonymizationException( "Could not find donation with id $id" );
 			}
-			$donation->scrubPersonalData( $cutoffDate );
+			$donation->scrubPersonalData( $exportCutoffDate, $moderationCutoffDate );
 			$this->donationRepository->storeDonation( $donation );
 
 			$counter++;

--- a/src/Domain/DonationAnonymizer.php
+++ b/src/Domain/DonationAnonymizer.php
@@ -18,6 +18,7 @@ interface DonationAnonymizer {
 	/**
 	 * Anonymize all donations that have been exported,
 	 * or are older than 2 days and have an incomplete payment (abandoned donations),
+	 * or are marked as moderated and older than 1 month
 	 * or are already deleted,
 	 *
 	 * @return int number of anonymized rows

--- a/src/Domain/DonationAnonymizer.php
+++ b/src/Domain/DonationAnonymizer.php
@@ -16,7 +16,9 @@ interface DonationAnonymizer {
 	public function anonymizeWithIds( int ...$donationIds ): void;
 
 	/**
-	 * Anonymize all donations that have been exported or are older than 2 days
+	 * Anonymize all donations that have been exported,
+	 * or are older than 2 days and have an incomplete payment (abandoned donations),
+	 * or are already deleted,
 	 *
 	 * @return int number of anonymized rows
 	 * @throws AnonymizationException

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -243,12 +243,12 @@ class Donation {
 		return $this->donatedOn;
 	}
 
-	public function scrubPersonalData( \DateTimeInterface $exportGracePeriodCutoffDate, \DateTimeInterface $moderationGracePeriodCutoffDate ): void {
-		if ( !$this->scrubbingIsAllowed( $exportGracePeriodCutoffDate, $moderationGracePeriodCutoffDate ) ) {
+	public function scrubPersonalData( \DateTimeInterface $externalIncompleteGracePeriodCutoffDate, \DateTimeInterface $moderationGracePeriodCutoffDate ): void {
+		if ( !$this->scrubbingIsAllowed( $externalIncompleteGracePeriodCutoffDate, $moderationGracePeriodCutoffDate ) ) {
 			throw new \DomainException(
 				sprintf(
 					"You must not anonymize unexported donations before %s, neither moderated donations before %s, otherwise you'd lose data. Offending donation ID: %s",
-					$exportGracePeriodCutoffDate->format( 'Y-m-d H:i:s' ),
+					$externalIncompleteGracePeriodCutoffDate->format( 'Y-m-d H:i:s' ),
 					$moderationGracePeriodCutoffDate->format( 'Y-m-d H:i:s' ),
 					$this->getId()
 			)
@@ -272,9 +272,6 @@ class Donation {
 	 *          which allows for the donation on 2024-12-11 to be scrubbed
 	 */
 	private function scrubbingIsAllowed( \DateTimeInterface $exportGracePeriodCutoffDate, \DateTimeInterface $moderationGracePeriodCutoffDate ): bool {
-		if ( $this->donorIsScrubbed() ) {
-			return false;
-		}
 		if ( $this->isExported() ) {
 			return true;
 		}

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -243,13 +243,16 @@ class Donation {
 		return $this->donatedOn;
 	}
 
-	public function scrubPersonalData( \DateTimeInterface $exportGracePeriodCutoffDate ): void {
-		if ( !$this->scrubbingIsAllowed( $exportGracePeriodCutoffDate ) ) {
-			throw new \DomainException( sprintf(
-				"You must not anonymize unexported donations before %s, otherwise you'd lose data. Offending donation ID: %s",
-				$exportGracePeriodCutoffDate->format( 'Y-m-d H:i:s' ),
-				$this->getId()
-			) );
+	public function scrubPersonalData( \DateTimeInterface $exportGracePeriodCutoffDate, \DateTimeInterface $moderationGracePeriodCutoffDate ): void {
+		if ( !$this->scrubbingIsAllowed( $exportGracePeriodCutoffDate, $moderationGracePeriodCutoffDate ) ) {
+			throw new \DomainException(
+				sprintf(
+					"You must not anonymize unexported donations before %s, neither moderated donations before %s, otherwise you'd lose data. Offending donation ID: %s",
+					$exportGracePeriodCutoffDate->format( 'Y-m-d H:i:s' ),
+					$moderationGracePeriodCutoffDate->format( 'Y-m-d H:i:s' ),
+					$this->getId()
+			)
+			);
 		}
 		$this->donor = new ScrubbedDonor(
 			new ScrubbedName( $this->donor->getName()->getSalutation() ),
@@ -268,7 +271,7 @@ class Donation {
 	 *          for the grace period will lead to a cutoff date of 2024-12-12,
 	 *          which allows for the donation on 2024-12-11 to be scrubbed
 	 */
-	private function scrubbingIsAllowed( \DateTimeInterface $exportGracePeriodCutoffDate ): bool {
+	private function scrubbingIsAllowed( \DateTimeInterface $exportGracePeriodCutoffDate, \DateTimeInterface $moderationGracePeriodCutoffDate ): bool {
 		if ( $this->donorIsScrubbed() ) {
 			return false;
 		}
@@ -279,6 +282,9 @@ class Donation {
 			return true;
 		}
 		if ( $this->isCancelled() ) {
+			return true;
+		}
+		if ( $this->isMarkedForModeration() && $this->donatedOn <= $moderationGracePeriodCutoffDate ) {
 			return true;
 		}
 		return false;

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -269,10 +269,16 @@ class Donation {
 	 *          which allows for the donation on 2024-12-11 to be scrubbed
 	 */
 	private function scrubbingIsAllowed( \DateTimeInterface $exportGracePeriodCutoffDate ): bool {
+		if ( $this->donorIsScrubbed() ) {
+			return false;
+		}
 		if ( $this->isExported() ) {
 			return true;
 		}
 		if ( $this->donatedOn <= $exportGracePeriodCutoffDate ) {
+			return true;
+		}
+		if ( $this->isCancelled() ) {
 			return true;
 		}
 		return false;

--- a/tests/Data/ValidDoctrineDonation.php
+++ b/tests/Data/ValidDoctrineDonation.php
@@ -30,6 +30,12 @@ class ValidDoctrineDonation {
 		return $donation;
 	}
 
+	public static function newDeletedDoctrineDonation(): Donation {
+		$donation = ( new self() )->createDonation();
+		$donation->setStatus( 'D' );
+		return $donation;
+	}
+
 	public static function newPaypalDoctrineDonation(): Donation {
 		$self = new self();
 		$donation = $self->createDonation();

--- a/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
@@ -12,6 +12,8 @@ use WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationRepository;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation as DoctrineDonation;
 use WMDE\Fundraising\DonationContext\DataAccess\ModerationReasonRepository;
 use WMDE\Fundraising\DonationContext\Domain\AnonymizationException;
+use WMDE\Fundraising\DonationContext\Domain\Model\ModerationIdentifier;
+use WMDE\Fundraising\DonationContext\Domain\Model\ModerationReason;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDoctrineDonation;
 use WMDE\Fundraising\DonationContext\Tests\TestEnvironment;
@@ -59,8 +61,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 		$count = $anonymizer->anonymizeAll();
 
-		$this->assertSame( 5, $count );
-		$this->assertNumberOfScrubbedDonations( 6 );
+		$this->assertSame( 6, $count );
+		$this->assertNumberOfScrubbedDonations( 7 );
 	}
 
 	public function testGivenDonation_anonymizeWillAnonymizeIt(): void {
@@ -116,6 +118,15 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		return $donation;
 	}
 
+	private function newModeratedDonation( int $id = self::DEFAULT_DONATION_ID ): DoctrineDonation {
+		$donation = ValidDoctrineDonation::newBankTransferDonation();
+		$donation->setId( $id );
+		$donation->setCreationTime( ( new \DateTime() )->sub( new \DateInterval( 'P2M' ) ) );
+		$donation->setModerationReasons( new ModerationReason( ModerationIdentifier::ADDRESS_CONTENT_VIOLATION ) );
+		$donation->setStatus( 'P' );
+		return $donation;
+	}
+
 	private function newExportedDonation( int $id = self::DEFAULT_DONATION_ID ): DoctrineDonation {
 		$donation = ValidDoctrineDonation::newExportedirectDebitDoctrineDonation();
 		$donation->setDtBackup( $this->anonymizationMarkerTime );
@@ -123,6 +134,9 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		return $donation;
 	}
 
+	/**
+	 * @return DoctrineDonation donation with an incomplete payment
+	 */
 	private function newUnExportedDonation( int $id, \DateTime $donationDate ): DoctrineDonation {
 		$donation = ValidDoctrineDonation::newIncompletePaypalDonation();
 		$donation->setCreationTime( $donationDate );
@@ -156,8 +170,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		$this->entityManager->persist( $this->newExportedDonation( 2 ) );
 		$this->entityManager->persist( $this->newExportedDonation( 3 ) );
 
-		// Insert un-exported donation that is older than two days, should be scrubbed
-		$threeDaysAgo = \DateTime::createFromImmutable( $this->clock->now()->modify( '-3 days' ) );
+		// Insert un-exported (incomplete payment) donation that is older than two days, should be scrubbed
+		$threeDaysAgo = \DateTime::createFromImmutable( $this->clock->now()->modify( '-1 month' ) );
 		$this->entityManager->persist( $this->newUnExportedDonation( 4, $threeDaysAgo ) );
 
 		// Insert un-exported donation that is just created, that should NOT be scrubbed
@@ -168,6 +182,9 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 		// Insert an already canceled/soft-deleted donation, should be scrubbed
 		$this->entityManager->persist( $this->newDeletedDonation( 7 ) );
+
+		// Insert an old, moderated donation, should be scrubbed (after grace period)
+		$this->entityManager->persist( $this->newModeratedDonation( 8 ) );
 
 		$this->entityManager->flush();
 	}

--- a/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
@@ -51,8 +51,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 		$count = $anonymizer->anonymizeAll();
 
-		$this->assertSame( 3, $count );
-		$this->assertNumberOfScrubbedDonations( 4 );
+		$this->assertSame( 5, $count );
+		$this->assertNumberOfScrubbedDonations( 6 );
 	}
 
 	public function testGivenDonation_anonymizeWillAnonymizeIt(): void {
@@ -86,6 +86,12 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 	private function newScrubbedDonation( int $id = self::DEFAULT_DONATION_ID ): DoctrineDonation {
 		$donation = ValidDoctrineDonation::newScrubbedDonation();
+		$donation->setId( $id );
+		return $donation;
+	}
+
+	private function newDeletedDonation( int $id = self::DEFAULT_DONATION_ID ): DoctrineDonation {
+		$donation = ValidDoctrineDonation::newDeletedDoctrineDonation();
 		$donation->setId( $id );
 		return $donation;
 	}
@@ -130,8 +136,7 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		$this->entityManager->persist( $this->newExportedDonation( 2 ) );
 		$this->entityManager->persist( $this->newExportedDonation( 3 ) );
 
-		// Insert un-exported donation that is older than two days, that should also be scrubbed
-		// This does not work, only when https://phabricator.wikimedia.org/T401247 is implemented
+		// Insert un-exported donation that is older than two days, should be scrubbed
 		$threeDaysAgo = \DateTime::createFromImmutable( $this->clock->now()->modify( '-3 days' ) );
 		$this->entityManager->persist( $this->newUnExportedDonation( 4, $threeDaysAgo ) );
 
@@ -140,6 +145,9 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 		// Insert an already scrubbed donation, that should NOT be scrubbed
 		$this->entityManager->persist( $this->newScrubbedDonation( 6 ) );
+
+		// Insert an already canceled/soft-deleted donation, should be scrubbed
+		$this->entityManager->persist( $this->newDeletedDonation( 7 ) );
 
 		$this->entityManager->flush();
 	}

--- a/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
@@ -28,7 +28,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 	private EntityManager $entityManager;
 
 	private \DateTime $anonymizationMarkerTime;
-	private \DateInterval $gracePeriod;
+	private \DateInterval $exportGracePeriod;
+	private \DateInterval $moderationGracePeriod;
 	private SystemClock $clock;
 
 	public function setUp(): void {
@@ -42,12 +43,19 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 			new ModerationReasonRepository( $this->entityManager )
 		);
 		$this->clock = new SystemClock();
-		$this->gracePeriod = new \DateInterval( 'P2D' );
+		$this->exportGracePeriod = new \DateInterval( 'P2D' );
+		$this->moderationGracePeriod = new \DateInterval( 'P1M' );
 	}
 
 	public function testAnonymizeAllReturnsNumberOfAnonymizedDonations(): void {
 		$this->insertExampleDonations();
-		$anonymizer = new DatabaseDonationAnonymizer( $this->donationRepository, $this->entityManager, $this->clock, $this->gracePeriod );
+		$anonymizer = new DatabaseDonationAnonymizer(
+			$this->donationRepository,
+			$this->entityManager,
+			$this->clock,
+			$this->exportGracePeriod,
+			$this->moderationGracePeriod
+		);
 
 		$count = $anonymizer->anonymizeAll();
 
@@ -57,7 +65,13 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 
 	public function testGivenDonation_anonymizeWillAnonymizeIt(): void {
 		$this->insertOneRow();
-		$anonymizer = new DatabaseDonationAnonymizer( $this->donationRepository, $this->entityManager, $this->clock, $this->gracePeriod );
+		$anonymizer = new DatabaseDonationAnonymizer(
+			$this->donationRepository,
+			$this->entityManager,
+			$this->clock,
+			$this->exportGracePeriod,
+			$this->moderationGracePeriod
+		);
 
 		$anonymizer->anonymizeWithIds( self::DEFAULT_DONATION_ID );
 
@@ -68,7 +82,13 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		$missingDonationId = 42;
 		$this->expectException( AnonymizationException::class );
 		$this->expectExceptionMessageMatches( "/Could not find donation with id $missingDonationId/" );
-		$anonymizer = new DatabaseDonationAnonymizer( $this->donationRepository, $this->entityManager, $this->clock, $this->gracePeriod );
+		$anonymizer = new DatabaseDonationAnonymizer(
+			$this->donationRepository,
+			$this->entityManager,
+			$this->clock,
+			$this->exportGracePeriod,
+			$this->moderationGracePeriod
+		);
 
 		$anonymizer->anonymizeWithIds( $missingDonationId );
 	}

--- a/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -171,7 +171,10 @@ class DoctrineDonationRepositoryTest extends TestCase {
 	public function testScrubbedDonationPersistenceRoundTrip(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->markAsExported( new \DateTimeImmutable( '2024-06-21 00:05:00' ) );
-		$donation->scrubPersonalData( new \DateTimeImmutable() );
+		$donation->scrubPersonalData(
+			externalIncompleteGracePeriodCutoffDate:  new \DateTimeImmutable(),
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
 
 		$repository = $this->newRepository();
 
@@ -327,7 +330,10 @@ class DoctrineDonationRepositoryTest extends TestCase {
 		$repository->storeDonation( $donation );
 		$this->entityManager->clear();
 
-		$donation->scrubPersonalData( new \DateTimeImmutable() );
+		$donation->scrubPersonalData(
+			externalIncompleteGracePeriodCutoffDate: new \DateTimeImmutable(),
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
 		$repository->storeDonation( $donation );
 
 		$connection = $this->entityManager->getConnection();

--- a/tests/Unit/Domain/Model/DonationTest.php
+++ b/tests/Unit/Domain/Model/DonationTest.php
@@ -172,7 +172,7 @@ class DonationTest extends TestCase {
 		$this->assertTrue( $donation->getDonor()->isSubscribedToMailingList(), 'We expect the fixture to be subscribed to the mailing list' );
 
 		$donation->scrubPersonalData(
-			exportGracePeriodCutoffDate: new \DateTimeImmutable(),
+			externalIncompleteGracePeriodCutoffDate: new \DateTimeImmutable(),
 			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
 		);
 
@@ -183,7 +183,7 @@ class DonationTest extends TestCase {
 		$this->assertInstanceOf( ScrubbedDonor::class, $donation->getDonor() );
 	}
 
-	public function testPreventsAnonymizeDonationOnUnexportedDonationsAfterTheExportCutoffDate(): void {
+	public function testPreventsAnonymizeDonationOnUnexportedDonationsAfterTheExternalIncompleteCutoffDate(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->assertFalse( $donation->isExported(), "we expect the incomplete donation to be not exported" );
 		$cutoffDateInsideGracePeriod = $donation->getDonatedOn()->sub( new \DateInterval( 'PT1H' ) );
@@ -191,22 +191,22 @@ class DonationTest extends TestCase {
 		$this->expectException( \DomainException::class );
 
 		$donation->scrubPersonalData(
-			exportGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
+			externalIncompleteGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
 			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
 		);
 	}
 
-	public function testPreventsAnonymizeDonationOnUnapprovedDonationsAfterTheModerationCutoffDate(): void {
+	public function testAllowsAnonymizeDonationOnUnapprovedDonationsAfterTheModerationCutoffDate(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$donation->markForModeration( new ModerationReason( ModerationIdentifier::MANUALLY_FLAGGED_BY_ADMIN ) );
 		$cutoffDateInsideGracePeriod = $donation->getDonatedOn()->sub( new \DateInterval( 'PT1H' ) );
 
-		$this->expectException( \DomainException::class );
-
 		$donation->scrubPersonalData(
-			exportGracePeriodCutoffDate: new \DateTimeImmutable(),
+			externalIncompleteGracePeriodCutoffDate: new \DateTimeImmutable(),
 			moderationGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
 		);
+
+		$this->assertTrue( $donation->donorIsScrubbed(), 'Donor should be scrubbed' );
 	}
 
 	public function testAllowsAnonymizeDonationOnUnexportedDonationsBeforeTheCutoffDate(): void {
@@ -215,7 +215,7 @@ class DonationTest extends TestCase {
 		$cutoffDateInsideGracePeriod = $donation->getDonatedOn()->modify( "+1 hour" );
 
 		$donation->scrubPersonalData(
-			exportGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
+			externalIncompleteGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
 			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
 		);
 
@@ -230,7 +230,7 @@ class DonationTest extends TestCase {
 		$originalSalutation = $donation->getDonor()->getName()->getSalutation();
 		$donation->markAsExported();
 		$donation->scrubPersonalData(
-			exportGracePeriodCutoffDate: new \DateTimeImmutable(),
+			externalIncompleteGracePeriodCutoffDate: new \DateTimeImmutable(),
 			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
 		);
 

--- a/tests/Unit/Domain/Model/DonationTest.php
+++ b/tests/Unit/Domain/Model/DonationTest.php
@@ -171,7 +171,10 @@ class DonationTest extends TestCase {
 		$this->assertTrue( $donation->getDonor()->wantsReceipt(), 'We expect the fixture to want a receipt' );
 		$this->assertTrue( $donation->getDonor()->isSubscribedToMailingList(), 'We expect the fixture to be subscribed to the mailing list' );
 
-		$donation->scrubPersonalData( new \DateTimeImmutable() );
+		$donation->scrubPersonalData(
+			exportGracePeriodCutoffDate: new \DateTimeImmutable(),
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
 
 		$this->assertTrue( $donation->donorIsAnonymous(), 'Donor should be anonymous' );
 		$this->assertTrue( $donation->donorIsScrubbed(), 'Donor should be scrubbed' );
@@ -180,14 +183,30 @@ class DonationTest extends TestCase {
 		$this->assertInstanceOf( ScrubbedDonor::class, $donation->getDonor() );
 	}
 
-	public function testPreventsAnonymizeDonationOnUnexportedDonationsAfterTheCutoffDate(): void {
+	public function testPreventsAnonymizeDonationOnUnexportedDonationsAfterTheExportCutoffDate(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->assertFalse( $donation->isExported(), "we expect the incomplete donation to be not exported" );
 		$cutoffDateInsideGracePeriod = $donation->getDonatedOn()->sub( new \DateInterval( 'PT1H' ) );
 
 		$this->expectException( \DomainException::class );
 
-		$donation->scrubPersonalData( $cutoffDateInsideGracePeriod );
+		$donation->scrubPersonalData(
+			exportGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
+	}
+
+	public function testPreventsAnonymizeDonationOnUnapprovedDonationsAfterTheModerationCutoffDate(): void {
+		$donation = ValidDonation::newIncompleteCreditCardDonation();
+		$donation->markForModeration( new ModerationReason( ModerationIdentifier::MANUALLY_FLAGGED_BY_ADMIN ) );
+		$cutoffDateInsideGracePeriod = $donation->getDonatedOn()->sub( new \DateInterval( 'PT1H' ) );
+
+		$this->expectException( \DomainException::class );
+
+		$donation->scrubPersonalData(
+			exportGracePeriodCutoffDate: new \DateTimeImmutable(),
+			moderationGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
+		);
 	}
 
 	public function testAllowsAnonymizeDonationOnUnexportedDonationsBeforeTheCutoffDate(): void {
@@ -195,7 +214,10 @@ class DonationTest extends TestCase {
 		$this->assertFalse( $donation->isExported(), "we expect the incomplete donation to be not exported" );
 		$cutoffDateInsideGracePeriod = $donation->getDonatedOn()->modify( "+1 hour" );
 
-		$donation->scrubPersonalData( $cutoffDateInsideGracePeriod );
+		$donation->scrubPersonalData(
+			exportGracePeriodCutoffDate: $cutoffDateInsideGracePeriod,
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
 
 		$this->assertTrue( $donation->donorIsAnonymous(), 'Donor should be anonymous' );
 		$this->assertTrue( $donation->donorIsScrubbed(), 'Donor should be scrubbed' );
@@ -207,7 +229,10 @@ class DonationTest extends TestCase {
 		$this->assertFalse( $donation->donorIsAnonymous(), 'We expect the fixture to be non-anonymous' );
 		$originalSalutation = $donation->getDonor()->getName()->getSalutation();
 		$donation->markAsExported();
-		$donation->scrubPersonalData( new \DateTimeImmutable() );
+		$donation->scrubPersonalData(
+			exportGracePeriodCutoffDate: new \DateTimeImmutable(),
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
 
 		$this->assertSame( $originalSalutation, $donation->getDonor()->getName()->getSalutation() );
 	}


### PR DESCRIPTION
- we needed to remove some parts of the scrubbing statement in 2025 because we noticed we scrubbed too much / not correctly
- this commit re-introduces scrubbing abandoned donations, deleted donations, and exported donations

Ticket: https://phabricator.wikimedia.org/T418399

this also implements  the `fundraising-donations` section of https://phabricator.wikimedia.org/T401247