### PR TITLE
Improve donation scrubbing

### DIFF
--- a/src/DataAccess/DatabaseDonationAnonymizer.php
+++ b/src/DataAccess/DatabaseDonationAnonymizer.php
@@ -1,10 +1,12 @@
 <?php
-declare( strict_types=1 );
+
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\DonationContext\DataAccess;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManager;
+use Symfony\Component\Console\Output\OutputInterface;
 use WMDE\Clock\Clock;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation;
 use WMDE\Fundraising\DonationContext\DataAccess\LegacyConverters\LegacyToDomainConverter;
@@ -30,7 +32,8 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 		private readonly Clock $clock,
 		private readonly \DateInterval $exportGracePeriod,
 		private readonly \DateInterval $moderationGracePeriod,
-		private readonly PaymentAnonymizer $paymentAnonymizer
+		private readonly PaymentAnonymizer $paymentAnonymizer,
+		private readonly OutputInterface $ouput
 	) {
 	}
 
@@ -40,12 +43,21 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 		$counter = 0;
 		$paymentIds = [];
 		foreach ( $donationIds as $id ) {
-			$donation = $this->donationRepository->getDonationById( $id );
-			if ( $donation === null ) {
-				throw new AnonymizationException( "Could not find donation with id $id" );
+
+			try {
+				$donation = $this->donationRepository->getDonationById( $id );
+
+				if ( $donation === null ) {
+					throw new AnonymizationException( "Could not find donation with id $id" );
+				}
+
+				$donation->scrubPersonalData( $externalIncompleteCutoffDate, $moderationCutoffDate );
+				$this->donationRepository->storeDonation( $donation );
+			} catch ( \Exception $e ) {
+				$this->ouput->writeln( $e->getMessage() );
+				$this->ouput->writeln( "Failed donation id: $id" );
+				continue;
 			}
-			$donation->scrubPersonalData( $externalIncompleteCutoffDate, $moderationCutoffDate );
-			$this->donationRepository->storeDonation( $donation );
 
 			$paymentIds[] = $donation->getPaymentId();
 
@@ -75,7 +87,7 @@ class DatabaseDonationAnonymizer implements DonationAnonymizer {
 
 			->where( 'd.isScrubbed = 0' )
 
-			->andWhere(	$qb->expr()->orX(
+			->andWhere( $qb->expr()->orX(
 
 				// scrub all already exported donations
 				$qb->expr()->isNotNull( 'd.dtGruen' ),

--- a/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
+++ b/src/DataAccess/LegacyConverters/DomainToLegacyConverter.php
@@ -182,6 +182,7 @@ class DomainToLegacyConverter {
 	private function modifyDonationForAnonymousDonor( Donor $donor, DoctrineDonation $doctrineDonation ): void {
 		if ( $donor instanceof Donor\ScrubbedDonor ) {
 			$doctrineDonation->scrub();
+			$doctrineDonation->setBankTransferCode( '' );
 			DataBlobScrubber::scrubAllPersonalData( $doctrineDonation );
 		} elseif ( $donor instanceof Donor\AnonymousDonor ) {
 			DataBlobScrubber::makeDonorAnonymous( $doctrineDonation );

--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\ScrubbedName;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\RecurringDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\ScrubbedDonor;
 
 class Donation {
@@ -242,7 +243,10 @@ class Donation {
 	public function createFollowupDonationForPayment( int $donationId, int $paymentId ): self {
 		return new Donation(
 			$donationId,
-			$this->getDonor(),
+			new RecurringDonor(
+				new ScrubbedName( $this->donor->getName()->getSalutation() ),
+				$this->getDonor()->getDonorType()
+			),
 			$paymentId,
 			$this->getTrackingInfo(),
 			// We don't want to clone comments for followup donations because they would show up again in the feed.

--- a/src/Domain/Model/Donor/RecurringDonor.php
+++ b/src/Domain/Model/Donor/RecurringDonor.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\DonationContext\Domain\Model\Donor;
+
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Address\ScrubbedAddress;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\ScrubbedName;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
+
+/**
+ * We need to set a donor when we recieve recurring donations from PayPal. The parent
+ * donation is a scrubbed donor, but using that will cause is_scrubbed to be set on
+ * the follow up donation before it is exported.
+ */
+class RecurringDonor extends AbstractDonor {
+	use MailingListTrait;
+	use ReceiptTrait;
+
+	public function __construct(
+		ScrubbedName $name,
+		private readonly DonorType $originalDonorType
+	) {
+		$this->name = $name;
+		$this->physicalAddress = new ScrubbedAddress();
+		$this->emailAddress = '';
+
+		// We don't care about these for recurring donations
+		$this->unsubscribeFromMailingList();
+		$this->declineReceipt();
+	}
+
+	public function isPrivatePerson(): bool {
+		return false;
+	}
+
+	public function isCompany(): bool {
+		return false;
+	}
+
+	public function getDonorType(): DonorType {
+		return $this->originalDonorType;
+	}
+}

--- a/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
+++ b/tests/Integration/DataAccess/DatabaseDonationAnonymizerTest.php
@@ -5,13 +5,13 @@ namespace WMDE\Fundraising\DonationContext\Tests\Integration\DataAccess;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 use WMDE\Clock\SystemClock;
 use WMDE\Fundraising\DonationContext\DataAccess\DatabaseDonationAnonymizer;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationExistsChecker;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineDonationRepository;
 use WMDE\Fundraising\DonationContext\DataAccess\DoctrineEntities\Donation as DoctrineDonation;
 use WMDE\Fundraising\DonationContext\DataAccess\ModerationReasonRepository;
-use WMDE\Fundraising\DonationContext\Domain\AnonymizationException;
 use WMDE\Fundraising\DonationContext\Domain\Model\ModerationIdentifier;
 use WMDE\Fundraising\DonationContext\Domain\Model\ModerationReason;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationRepository;
@@ -59,7 +59,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 			$this->clock,
 			$this->exportGracePeriod,
 			$this->moderationGracePeriod,
-			new FakePaymentAnonymizer()
+			new FakePaymentAnonymizer(),
+			$this->createStub( OutputInterface::class )
 		);
 
 		$count = $anonymizer->anonymizeAll();
@@ -77,7 +78,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 			$this->clock,
 			$this->exportGracePeriod,
 			$this->moderationGracePeriod,
-			$paymentAnonymizer
+			$paymentAnonymizer,
+			$this->createStub( OutputInterface::class )
 		);
 
 		$anonymizer->anonymizeAll();
@@ -100,7 +102,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 			$this->clock,
 			$this->exportGracePeriod,
 			$this->moderationGracePeriod,
-			new FakePaymentAnonymizer()
+			new FakePaymentAnonymizer(),
+			$this->createStub( OutputInterface::class )
 		);
 
 		$anonymizer->anonymizeWithIds( self::DEFAULT_DONATION_ID );
@@ -117,7 +120,8 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 			$this->clock,
 			$this->exportGracePeriod,
 			$this->moderationGracePeriod,
-			$paymentAnonymizer
+			$paymentAnonymizer,
+			$this->createStub( OutputInterface::class )
 		);
 
 		$anonymizer->anonymizeWithIds( self::DEFAULT_DONATION_ID );
@@ -125,17 +129,26 @@ class DatabaseDonationAnonymizerTest extends TestCase {
 		$this->assertSame( [ ValidPayments::ID_DIRECT_DEBIT ], $paymentAnonymizer->paymentIds );
 	}
 
-	public function testGivenNoDonation_anonymizeWillThrow(): void {
+	public function testGivenNoDonation_anonymizeWillOutput(): void {
 		$missingDonationId = 42;
-		$this->expectException( AnonymizationException::class );
-		$this->expectExceptionMessageMatches( "/Could not find donation with id $missingDonationId/" );
+
+		$output = $this->createMock( OutputInterface::class );
+		$output->expects( $this->exactly( 2 ) )
+			->method( 'writeln' )
+			->with( $this->logicalOr(
+				$this->equalTo( "Could not find donation with id $missingDonationId" ),
+				$this->equalTo( "Failed donation id: $missingDonationId" )
+			)
+		);
+
 		$anonymizer = new DatabaseDonationAnonymizer(
 			$this->donationRepository,
 			$this->entityManager,
 			$this->clock,
 			$this->exportGracePeriod,
 			$this->moderationGracePeriod,
-			new FakePaymentAnonymizer()
+			new FakePaymentAnonymizer(),
+			$output
 		);
 
 		$anonymizer->anonymizeWithIds( $missingDonationId );

--- a/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -374,7 +374,7 @@ class DoctrineDonationRepositoryTest extends TestCase {
 		], $data );
 	}
 
-	public function testWhenScrubbingDonation_allUnneededDataISClearedFromDataBlob(): void {
+	public function testWhenScrubbingDonation_allUnneededDataIsClearedFromDataBlob(): void {
 		$donationId = 3;
 		$donation = ValidDonation::newBookedPayPalDonation( $donationId );
 		$donation->markAsExported();
@@ -411,6 +411,28 @@ class DoctrineDonationRepositoryTest extends TestCase {
 			'anrede' => 'nyan',
 			'adresstyp' => 'person'
 		], $data );
+	}
+
+	public function testWhenScrubbingBankTransferDonation_repositoryRemovesUEBCode(): void {
+		$donationId = 3;
+		$donation = ValidDonation::newBankTransferDonation( $donationId );
+		$this->legacyPaymentData = ValidPayments::newBankTransferPayment()->getLegacyData();
+		$donation->markAsExported();
+		$repository = $this->newRepository();
+		$repository->storeDonation( $donation );
+		$this->entityManager->clear();
+
+		$donation->scrubPersonalData(
+			externalIncompleteGracePeriodCutoffDate: new \DateTimeImmutable(),
+			moderationGracePeriodCutoffDate: new \DateTimeImmutable()
+		);
+		$repository->storeDonation( $donation );
+
+		$connection = $this->entityManager->getConnection();
+		$row = $connection->executeQuery( "SELECT * FROM spenden WHERE id=$donationId" )->fetchAssociative();
+		$this->assertIsArray( $row );
+
+		$this->assertSame( '', $row[ 'ueb_code' ] );
 	}
 
 	public function testPublicCommentStaysPersistedWhenDonationIsScrubbed(): void {

--- a/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -473,6 +473,34 @@ class DoctrineDonationRepositoryTest extends TestCase {
 		$this->assertSame( '', $row[ 'kommentar' ] );
 	}
 
+	public function testFollowUpDonationIsNotMarkedAsScrubbed(): void {
+		$donation = ValidDonation::newBookedPayPalDonation();
+		$donation->markAsExported();
+		$donation->scrubPersonalData( new \DateTimeImmutable(), new \DateTimeImmutable() );
+
+		$repository = $this->newRepository();
+		$repository->storeDonation( $donation );
+		$this->entityManager->clear();
+
+		$followUpDonation = $donation->createFollowupDonationForPayment( 42, 2 );
+
+		$repository->storeDonation( $followUpDonation );
+
+		echo $donation->getId();
+		echo $followUpDonation->getId();
+
+		$connection = $this->entityManager->getConnection();
+		$row = $connection->executeQuery( "SELECT * FROM spenden WHERE id = 42" )->fetchAssociative();
+
+		$this->assertIsArray( $row );
+		$this->assertSame( 0, $row[ 'is_scrubbed' ] );
+
+		// @phpstan-ignore argument.type
+		$data = unserialize( base64_decode( $row['data'] ) );
+		$this->assertIsArray( $data );
+		$this->assertSame( 'nyan', $data[ 'anrede' ] );
+	}
+
 	private function newEntityManagerThatThrowsWithQueryBuilder(): EntityManager {
 		$query = $this->createStub( Query::class );
 		$query->method( 'getOneOrNullResult' )

--- a/tests/Unit/DataAccess/LegacyConverters/DomainToLegacyConverterTest.php
+++ b/tests/Unit/DataAccess/LegacyConverters/DomainToLegacyConverterTest.php
@@ -246,4 +246,24 @@ class DomainToLegacyConverterTest extends TestCase {
 
 		$this->assertSame( DoctrineDonation::STATUS_EXTERNAL_INCOMPLETE, $updatedDoctrineDonation->getStatus() );
 	}
+
+	public function testGivenScrubbedBankTransferDonationClearsUEBCode(): void {
+		$converter = new DomainToLegacyConverter();
+		$donation = ValidDonation::newBankTransferDonation();
+		$donation->markAsExported( new \DateTimeImmutable() );
+		$donation->scrubPersonalData( new \DateTimeImmutable(), new \DateTimeImmutable() );
+
+		$legacyPaymentData = new LegacyPaymentData(
+			9999,
+			1,
+			'UEB',
+			[ 'ueb_code' => ValidPayments::PAYMENT_BANK_TRANSFER_CODE ],
+		);
+
+		$doctrineDonation = new DoctrineDonation();
+
+		$updatedDoctrineDonation = $converter->convert( $donation, $doctrineDonation, $legacyPaymentData, [] );
+
+		$this->assertSame( '', $updatedDoctrineDonation->getBankTransferCode() );
+	}
 }

--- a/tests/Unit/Domain/Model/DonationTest.php
+++ b/tests/Unit/Domain/Model/DonationTest.php
@@ -11,8 +11,11 @@ use RuntimeException;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\AnonymousDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\CompanyDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\ScrubbedName;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\PersonDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\RecurringDonor;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donor\ScrubbedDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\Domain\Model\ModerationIdentifier;
 use WMDE\Fundraising\DonationContext\Domain\Model\ModerationReason;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
@@ -133,8 +136,13 @@ class DonationTest extends TestCase {
 		$donation = ValidDonation::newBookedPayPalDonation( donationId: 1 );
 		$followupUpDonation = $donation->createFollowupDonationForPayment( donationId: 1, paymentId: 99 );
 
+		$expectedDonor = new RecurringDonor(
+			new ScrubbedName( ValidDonation::DONOR_SALUTATION ),
+			DonorType::PERSON
+		);
+
 		$this->assertSame( 99, $followupUpDonation->getPaymentId() );
-		$this->assertEquals( $followupUpDonation->getDonor(), $donation->getDonor() );
+		$this->assertEquals( $expectedDonor, $followupUpDonation->getDonor() );
 		$this->assertEquals( $followupUpDonation->getTrackingInfo(), $donation->getTrackingInfo() );
 		$this->assertFalse(
 			$followupUpDonation->isExported(),

--- a/tests/Unit/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
+++ b/tests/Unit/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentCompletionNotificationUseCaseTest.php
@@ -7,6 +7,9 @@ namespace WMDE\Fundraising\DonationContext\Tests\Unit\UseCases\HandlePayPalPayme
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\Name\ScrubbedName;
+use WMDE\Fundraising\DonationContext\Domain\Model\Donor\RecurringDonor;
+use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationIdRepository;
 use WMDE\Fundraising\DonationContext\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\DonationContext\Infrastructure\DonationAuthorizationChecker;
@@ -140,11 +143,16 @@ class HandlePayPalPaymentCompletionNotificationUseCaseTest extends TestCase {
 
 		$this->assertCount( 2, $repositoryCalls );
 
+		$expectedDonor = new RecurringDonor(
+			new ScrubbedName( ValidDonation::DONOR_SALUTATION ),
+			DonorType::PERSON
+		);
+
 		[ $donation, $followupUpDonation ] = array_values( $repositoryCalls );
 		$this->assertNotSame( $followupUpDonation->getId(), $donation->getId() );
-		$this->assertEquals( $followupUpDonation->getDonor(), $donation->getDonor() );
+		$this->assertEquals( $expectedDonor, $followupUpDonation->getDonor() );
 		$this->assertEquals( $followupUpDonation->getTrackingInfo(), $donation->getTrackingInfo() );
-		$this->assertEquals( $followupUpDonation->getOptsIntoNewsletter(), $donation->getOptsIntoNewsletter() );
+		$this->assertFalse( $followupUpDonation->getOptsIntoNewsletter() );
 		$this->assertFalse( $followupUpDonation->isExported() );
 	}
 


### PR DESCRIPTION
This is a continuation of https://github.com/wmde/fundraising-donations/pull/367 which was approved and merged.

**Make anonymizeWithIds output instead of throw**
We don't want to stop the anonymisation loop when
an exception is thrown, so instead we catch the
exception and convert it to output for the calling command.

**Add new recurring donor type**
When a recurring donation is created the donor
for the parent donation is added to it. If the
donation has been scrubbed that donor will be
an instance of a ScrubbedDonor, which causes
the follow up donation to be marked as scrubbed
before it is exported.
Ticket: https://phabricator.wikimedia.org/T430212